### PR TITLE
Feat: Add link from object page

### DIFF
--- a/src/components/EntitySelector.vue
+++ b/src/components/EntitySelector.vue
@@ -37,7 +37,8 @@
             prepend-icon="mdi-open-in-new"
             size="x-small"
             rounded="sm"
-            >open</v-btn
+            class="mt-2"
+            >details</v-btn
           >
         </div>
       </v-list-item>

--- a/src/components/EntitySelector.vue
+++ b/src/components/EntitySelector.vue
@@ -1,0 +1,115 @@
+<template>
+  <v-autocomplete
+    label="Search for entities or indicators"
+    :items="items"
+    item-title="name"
+    v-model="selectedEntity"
+    return-object
+    clearable
+    @update:search="updateItemsDebounced"
+    @update:model-value="emitSelectedObject"
+    :hide-details="inline"
+    :density="inline ? 'compact' : 'default'"
+  >
+    <template v-slot:no-data>
+      <v-list-item>
+        <v-list-item-title>Start typing...</v-list-item-title>
+      </v-list-item>
+    </template>
+    <template v-slot:chip="{ props, item }">
+      <v-chip
+        v-if="item.raw.type"
+        v-bind="props"
+        :text="item.raw.name"
+        :prepend-icon="getIconForType(item.raw.type)"
+      ></v-chip>
+    </template>
+
+    <template v-slot:item="{ props, item }">
+      <v-list-item :prepend-icon="getIconForType(item.raw.type)">
+        <div class="d-flex">
+          <v-btn variant="text" v-bind="props">{{ item.raw.name }}</v-btn>
+          <v-spacer></v-spacer>
+          <v-btn
+            variant="text"
+            :to="{ name: 'EntityDetails', params: { id: item.raw.id } }"
+            target="_blank"
+            prepend-icon="mdi-open-in-new"
+            size="x-small"
+            rounded="sm"
+            >open</v-btn
+          >
+        </div>
+      </v-list-item>
+    </template>
+  </v-autocomplete>
+</template>
+
+<script lang="ts" setup>
+import axios from "axios";
+
+import { ENTITY_TYPES } from "@/definitions/entityDefinitions.js";
+import { INDICATOR_TYPES } from "@/definitions/indicatorDefinitions.js";
+
+import _ from "lodash";
+</script>
+
+<script lang="ts">
+export default {
+  props: {
+    object: {
+      type: Object,
+      default: () => {}
+    },
+    isActive: {
+      type: Object,
+      default: () => {}
+    },
+    inline: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data() {
+    return {
+      errors: [],
+      items: [],
+      selectedEntity: null
+    };
+  },
+  methods: {
+    async loadObjects(searchQuery: String = "") {
+      if (searchQuery.length == 0) {
+        this.items = [];
+        return;
+      }
+      const params = { query: { name: searchQuery }, count: 0 };
+      const entities = (await axios.post("/api/v2/entities/search", params)).data.entities;
+      const indicators = (await axios.post("/api/v2/indicators/search", params)).data.indicators;
+      this.items = entities.concat(indicators).map(item => {
+        return {
+          id: item.id,
+          root_type: item.root_type,
+          name: item.name,
+          type: item.type
+        };
+      });
+    },
+    updateItemsDebounced: _.debounce(function (searchQuery) {
+      this.loadObjects(searchQuery);
+    }, 200),
+    emitSelectedObject() {
+      this.$emit("selected-object", this.selectedEntity);
+    },
+    getIconForType(type) {
+      return (ENTITY_TYPES.find(t => t.type === type) || INDICATOR_TYPES.find(t => t.type === type)).icon;
+    }
+  }
+};
+</script>
+
+<style>
+.yeti-code textarea {
+  font-family: monospace;
+}
+</style>

--- a/src/components/LinkObject.vue
+++ b/src/components/LinkObject.vue
@@ -1,0 +1,158 @@
+<template>
+  <v-card>
+    <v-card-title
+      >New link for <span class="text-primary">{{ object.name }}</span>
+    </v-card-title>
+    <v-card-text>
+      <v-autocomplete
+        label="Search for entities or indicators"
+        :items="items"
+        item-title="name"
+        v-model="linkTarget"
+        return-object
+        clearable
+      >
+        <template v-slot:chip="{ props, item }">
+          <v-chip
+            v-if="item.raw.type"
+            v-bind="props"
+            :text="item.raw.name"
+            :prepend-icon="getIconForType(item.raw.type)"
+          ></v-chip>
+        </template>
+
+        <template v-slot:item="{ props, item }">
+          <v-list-item :prepend-icon="getIconForType(item.raw.type)">
+            <div class="d-flex">
+              <v-btn variant="text" v-bind="props">{{ item.raw.name }}</v-btn>
+              <v-spacer></v-spacer>
+              <v-btn
+                variant="text"
+                :to="{ name: 'EntityDetails', params: { id: item.raw.id } }"
+                target="_blank"
+                prepend-icon="mdi-open-in-new"
+                size="x-small"
+                rounded="sm"
+                >open</v-btn
+              >
+            </div>
+          </v-list-item>
+        </template>
+      </v-autocomplete>
+      <v-text-field label="Link type" v-model="linkType"></v-text-field>
+      <v-textarea label="Link description (supports markdown)" v-model="linkDescription"></v-textarea>
+    </v-card-text>
+
+    <v-card-actions>
+      <v-spacer></v-spacer>
+      <v-btn text="Cancel" color="cancel" @click="isActive.value = false"></v-btn>
+      <v-btn text="Save" :disabled="linkTarget === null" @click="createLink"></v-btn>
+    </v-card-actions>
+    <v-alert v-if="errors.length > 0" type="error">
+      Error saving {{ typeDefinition.name }}:
+      <ul>
+        <li v-for="error in errors">
+          <strong>{{ error.field }}</strong
+          >: {{ error.message }}
+        </li>
+      </ul>
+    </v-alert>
+  </v-card>
+</template>
+
+<script lang="ts" setup>
+import axios from "axios";
+
+import { ENTITY_TYPES } from "@/definitions/entityDefinitions.js";
+import { INDICATOR_TYPES } from "@/definitions/indicatorDefinitions.js";
+
+import _ from "lodash";
+</script>
+
+<script lang="ts">
+export default {
+  props: {
+    object: {
+      type: Object,
+      default: () => {}
+    },
+    isActive: {
+      type: Object,
+      default: () => {}
+    }
+  },
+  data() {
+    return {
+      errors: [],
+      items: [],
+      linkTarget: null,
+      linkType: "",
+      linkDescription: ""
+    };
+  },
+  mounted() {
+    this.loadObjects();
+  },
+  methods: {
+    async loadObjects() {
+      const params = { query: { name: "" }, count: 0 };
+      let entities = (await axios.post("/api/v2/entities/search", params)).data.entities;
+      let indicators = (await axios.post("/api/v2/indicators/search", params)).data.indicators;
+      this.items = entities.concat(indicators).map(item => {
+        return {
+          id: item.id,
+          root_type: item.root_type,
+          name: item.name,
+          type: item.type
+        };
+      });
+    },
+    createLink() {
+      axios
+        .post("/api/v2/graph/add", {
+          source: `${this.object.root_type}/${this.object.id}`,
+          target: `${this.linkTarget.root_type}/${this.linkTarget.id}`,
+          link_type: this.linkType,
+          description: this.linkDescription
+        })
+        .then(response => {
+          this.isActive.value = false;
+          this.$eventBus.emit("displayMessage", {
+            message: `Link succesfully created`,
+            status: "success"
+          });
+          const linkData = {
+            source: {
+              id: this.object.id,
+              root_type: this.object.root_type,
+              type: this.object.type,
+              name: this.object.name
+            },
+            target: {
+              id: this.linkTarget.id,
+              root_type: this.linkTarget.root_type,
+              type: this.linkTarget.type,
+              name: this.linkTarget.name
+            },
+            link_type: this.linkType,
+            description: this.linkDescription,
+            id: response.data.id
+          };
+          this.$eventBus.emit("linkCreated", linkData);
+        })
+        .catch(error => {
+          this.errors = error.response.data.errors;
+        });
+    },
+    getIconForType(type) {
+      return (ENTITY_TYPES.find(t => t.type === type) || INDICATOR_TYPES.find(t => t.type === type)).icon;
+    }
+  }
+};
+</script>
+
+<style>
+.yeti-code textarea {
+  font-family: monospace;
+}
+</style>

--- a/src/components/ObjectList.vue
+++ b/src/components/ObjectList.vue
@@ -146,9 +146,11 @@ export default {
       let params = {
         page: page - 1,
         count: itemsPerPage,
-        type: this.searchSubtype,
         query: this.extractParamsFromSearchQuery(this.searchQuery, "name")
       };
+      if (this.searchSubtype != "") {
+        params["type"] = this.searchSubtype;
+      }
       axios.post(`/api/v2/${this.searchType}/search`, params).then(response => {
         this.items = response.data[this.searchType];
         if (response.data.total != this.total) {

--- a/src/components/RelatedObjects.vue
+++ b/src/components/RelatedObjects.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- Empty headers array to not mess up with CSS borders -->
   <v-data-table-server
     density="compact"
     :items="getNodeChain"
@@ -6,6 +7,7 @@
     :items-per-page="perPage"
     v-model:page="page"
     @update:options="fetchNeighbors"
+    :headers="[]"
     hover
   >
     <template v-slot:item="{ item }">

--- a/src/components/RelatedObjects.vue
+++ b/src/components/RelatedObjects.vue
@@ -161,7 +161,6 @@ export default {
         count: this.perPage,
         page: this.page - 1
       };
-      console.log("Fetching neighbors", graphSearchRequest);
 
       axios
         .post(`/api/v2/graph/search`, graphSearchRequest)

--- a/src/components/RelatedObjects.vue
+++ b/src/components/RelatedObjects.vue
@@ -115,6 +115,15 @@ export default {
     EditLink,
     YetiMarkdown
   },
+  mounted() {
+    this.$eventBus.on("linkCreated", data => {
+      const souceType = data.source.type;
+      const targetType = data.target.type;
+      if (this.targetTypes.includes(targetType) || this.targetTypes.includes(souceType)) {
+        this.fetchNeighbors();
+      }
+    });
+  },
   data() {
     return {
       tempChains: [],

--- a/src/views/ObjectDetails.vue
+++ b/src/views/ObjectDetails.vue
@@ -7,9 +7,12 @@
             <div class="d-flex">
               <v-chip class="mr-3" color="primary" :text="object?.type" label></v-chip>
               <code class="me-auto">{{ object?.name }}</code>
+
               <v-dialog :width="editWidth" :fullscreen="fullScreenEdit">
                 <template v-slot:activator="{ props }">
-                  <v-btn variant="tonal" color="primary" v-bind="props">Edit </v-btn>
+                  <v-btn class="me-2" variant="tonal" color="primary" v-bind="props" append-icon="mdi-pencil"
+                    >Edit
+                  </v-btn>
                 </template>
 
                 <template v-slot:default="{ isActive }">
@@ -19,6 +22,16 @@
                     @success="obj => (object = obj)"
                     @toggle-fullscreen="toggleFullscreen"
                   />
+                </template>
+              </v-dialog>
+
+              <v-dialog :width="editWidth">
+                <template v-slot:activator="{ props }">
+                  <v-btn variant="tonal" color="primary" v-bind="props" append-icon="mdi-link">new link </v-btn>
+                </template>
+
+                <template v-slot:default="{ isActive }">
+                  <link-object :object="object" :is-active="isActive" />
                 </template>
               </v-dialog>
             </div>
@@ -157,6 +170,7 @@ import DOMPurify from "dompurify";
 
 import RelatedObjects from "@/components/RelatedObjects.vue";
 import EditObject from "@/components/EditObject.vue";
+import LinkObject from "@/components/LinkObject.vue";
 import YetiMarkdown from "@/components/YetiMarkdown.vue";
 
 import { ENTITY_TYPES } from "@/definitions/entityDefinitions.js";
@@ -180,6 +194,8 @@ export default {
   },
   components: {
     RelatedObjects,
+    EditObject,
+    LinkObject,
     YetiMarkdown
   },
   data() {
@@ -268,7 +284,7 @@ export default {
       return this.getObjectTypeDefintiions?.fields.filter(field => !this.hideFieldsInfoBox.includes(field.field));
     },
     displayedEntityTypes() {
-      return this.objectTypes[this.objectType].filter(type => this.relatedEntitiesCount[type.type] > 0);
+      return this.objectTypes["entity"].filter(type => this.relatedEntitiesCount[type.type] > 0);
     }
   },
   mounted() {

--- a/src/views/ObservableMatch.vue
+++ b/src/views/ObservableMatch.vue
@@ -33,9 +33,9 @@
     </v-row>
     <v-row v-if="searchResults">
       <v-col>
-        <v-row>
-          <v-col cols="3">
-            <v-card class="mb-4">
+        <v-row class="mb-4">
+          <v-col cols="5">
+            <v-card>
               <v-card-title
                 >Related entities
                 <v-chip density="comfortable" class="ml-3">{{ entityMatches.length }}</v-chip></v-card-title
@@ -111,13 +111,13 @@
             <v-chip density="comfortable" class="ml-3">{{ searchResults.known.length }}</v-chip></v-card-title
           >
           <v-card-text v-if="searchResults.known.length > 0">
-            <div class="d-flex v-col-4 pl-0">
+            <div class="d-flex pl-0 mb-2">
               <v-btn
                 prepend-icon="mdi-tag"
                 class="me-3"
                 variant="tonal"
                 @click="tagKnown"
-                :disabled="addTagsKnown.length === 0"
+                :disabled="selectedKnown.length === 0"
                 >Tag
                 {{
                   selectedKnown.length === 0 || selectedKnown.length == searchResults.unknown.length
@@ -134,6 +134,22 @@
                 placeholder="Tags"
                 :delimiters="[',', ' ', ';']"
               ></v-combobox>
+            </div>
+            <div class="d-flex pl-0">
+              <v-btn
+                prepend-icon="mdi-link"
+                class="me-3"
+                variant="tonal"
+                @click="tagKnown"
+                :disabled="selectedKnown.length === 0"
+                >Link
+                {{
+                  selectedKnown.length === 0 || selectedKnown.length == searchResults.unknown.length
+                    ? "all"
+                    : selectedKnown.length
+                }}
+              </v-btn>
+              <entity-selector inline @selected-object="selection => (linkTarget = selection)" />
             </div>
             <v-data-table
               density="compact"
@@ -183,7 +199,7 @@
             Add unknown observables, with optional tags. Type will be guessed unless specified.
           </v-card-subtitle>
           <v-card-text v-if="searchResults.unknown.length > 0">
-            <div class="d-flex v-col-4 pl-0">
+            <div class="d-flex pl-0">
               <v-btn
                 prepend-icon="mdi-plus"
                 class="me-3"
@@ -235,12 +251,15 @@ import axios from "axios";
 import moment from "moment";
 import { OBSERVABLE_TYPES } from "@/definitions/observableDefinitions.js";
 import { ENTITY_TYPES } from "@/definitions/entityDefinitions.js";
+import EntitySelector from "@/components/EntitySelector.vue";
 </script>
 
 <script lang="ts">
 export default {
   name: "ObservableMatch",
-  components: {},
+  components: {
+    EntitySelector
+  },
   data() {
     return {
       // search field

--- a/src/views/ObservableMatch.vue
+++ b/src/views/ObservableMatch.vue
@@ -140,16 +140,16 @@
                 prepend-icon="mdi-link"
                 class="me-3"
                 variant="tonal"
-                @click="tagKnown"
-                :disabled="selectedKnown.length === 0"
+                @click="linkKnown"
+                :disabled="selectedKnown.length === 0 || knownLinkTarget === null"
                 >Link
                 {{
-                  selectedKnown.length === 0 || selectedKnown.length == searchResults.unknown.length
+                  selectedKnown.length === 0 || selectedKnown.length == searchResults.known.length
                     ? "all"
                     : selectedKnown.length
                 }}
               </v-btn>
-              <entity-selector inline @selected-object="selection => (linkTarget = selection)" />
+              <entity-selector inline @selected-object="selection => (knownLinkTarget = selection)" />
             </div>
             <v-data-table
               density="compact"
@@ -270,6 +270,7 @@ export default {
       addTagsSearch: [],
       // add / tag known / unknown observables
       addTagsKnown: [],
+      knownLinkTarget: null,
       addTagsUnknown: [],
       addTypeUnknown: "guess",
       selectedUnknown: [],
@@ -325,6 +326,24 @@ export default {
           });
         })
         .finally(() => {});
+    },
+    linkKnown() {
+      this.selectedKnown.forEach(observable => {
+        this.linkKnownObservable(observable, this.knownLinkTarget);
+      });
+      this.$eventBus.emit("displayMessage", {
+        status: "success",
+        message: `${this.selectedKnown.length} link requests sent`
+      });
+    },
+    linkKnownObservable(observable, linkTarget) {
+      let params = {
+        source: `${observable.root_type}/${observable.id}`,
+        target: `${linkTarget.root_type}/${linkTarget.id}`,
+        link_type: "match",
+        description: "match"
+      };
+      axios.post("/api/v2/graph/add", params);
     },
     addUknown() {
       const observables = this.selectedUnknown.map(obs => {


### PR DESCRIPTION
New modal in ObjectDetails view:

![image](https://github.com/yeti-platform/yeti-feeds-frontend/assets/1257972/5b809d3d-c3f4-4adc-b6ac-0329dbdd21e2)

Autocomplete 

![image](https://github.com/yeti-platform/yeti-feeds-frontend/assets/1257972/347a4481-a9f3-4b05-8fdb-42ce89c40d5b)

The related entities list is also auto-refreshed

Also adds a new control in the Observable Match page to link many observables to an entity:

<img width="1214" alt="image" src="https://github.com/yeti-platform/yeti-feeds-frontend/assets/1257972/ba53ed06-3dd6-4497-9930-3f9bd6d7aef6">