### PR TITLE
Add new observable button in Observables list view

### DIFF
--- a/src/components/NewObject.vue
+++ b/src/components/NewObject.vue
@@ -28,6 +28,7 @@ import axios from "axios";
 
 import { ENTITY_TYPES } from "@/definitions/entityDefinitions.js";
 import { INDICATOR_TYPES } from "@/definitions/indicatorDefinitions.js";
+import { OBSERVABLE_TYPES } from "@/definitions/observableDefinitions.js";
 import ObjectFields from "@/components/ObjectFields.vue";
 import { objectTypeAnnotation } from "@babel/types";
 </script>
@@ -48,7 +49,7 @@ export default {
       fullScreen: false,
       typeToEndpointMapping: {
         entity: "entities",
-        observable: "observables",
+        observable: "observables/extended",
         indicator: "indicators"
       }
     };
@@ -74,8 +75,21 @@ export default {
         })
         .then(response => {
           this.$eventBus.emit("displayMessage", { message: `New ${this.objectType} created`, status: "success" });
+          let _name = "";
+          if (response.data.root_type == "entity")
+          {
+            _name = "EntityDetails";
+          }
+          else if (response.data.root_type == "indicator")
+          {
+            _name = "IndicatorDetails";
+          }
+          else if (response.data.root_type == "observable")
+          {
+            _name = "ObservableDetails";
+          }
           this.$router.push({
-            name: response.data.root_type == "entity" ? "EntityDetails" : "IndicatorDetails",
+            name: _name,
             params: { id: response.data.id, type: response.data.type }
           });
         })
@@ -97,14 +111,30 @@ export default {
   computed: {
     typeDefinition() {
       return (
-        ENTITY_TYPES.find(t => t.type === this.objectType) || INDICATOR_TYPES.find(t => t.type === this.objectType)
-      );
+        ENTITY_TYPES.find(t => t.type === this.objectType) || INDICATOR_TYPES.find(t => t.type === this.objectType) || OBSERVABLE_TYPES.find(t => t.type === this.objectType)
+        );
     },
     editableFields() {
       return this.typeDefinition.fields.filter(field => field.editable);
     },
     objectRootType() {
-      return ENTITY_TYPES.find(t => t.type === this.objectType) ? "entity" : "indicator";
+      if ( ENTITY_TYPES.find(t => t.type === this.objectType) )
+      {
+        return "entity";
+      }
+      else if ( INDICATOR_TYPES.find(t => t.type === this.objectType) )
+      {
+        return "indicator";
+      }
+      else if ( OBSERVABLE_TYPES.find(t => t.type === this.objectType) )
+      {
+        return "observable";
+      }
+      else
+      {
+        return "unknown";
+      }
+//      return ENTITY_TYPES.find(t => t.type === this.objectType) ? "entity" : "indicator";
     }
   }
 };

--- a/src/components/NewObject.vue
+++ b/src/components/NewObject.vue
@@ -51,6 +51,11 @@ export default {
         entity: "entities",
         observable: "observables/extended",
         indicator: "indicators"
+      },
+      typeToSavedObjectPath: {
+        entity: "entities",
+        observable: "observables",
+        indicator: "indicators"
       }
     };
   },
@@ -75,23 +80,7 @@ export default {
         })
         .then(response => {
           this.$eventBus.emit("displayMessage", { message: `New ${this.objectType} created`, status: "success" });
-          let _name = "";
-          if (response.data.root_type == "entity")
-          {
-            _name = "EntityDetails";
-          }
-          else if (response.data.root_type == "indicator")
-          {
-            _name = "IndicatorDetails";
-          }
-          else if (response.data.root_type == "observable")
-          {
-            _name = "ObservableDetails";
-          }
-          this.$router.push({
-            name: _name,
-            params: { id: response.data.id, type: response.data.type }
-          });
+          this.$router.push({ path: `/${this.typeToSavedObjectPath[this.newObject.root_type]}/${response.data.id}` });
         })
         .catch(error => {
           console.log(error);
@@ -134,7 +123,6 @@ export default {
       {
         return "unknown";
       }
-//      return ENTITY_TYPES.find(t => t.type === this.objectType) ? "entity" : "indicator";
     }
   }
 };

--- a/src/views/ObservableSearch.vue
+++ b/src/views/ObservableSearch.vue
@@ -54,27 +54,27 @@
         class="mt-2"
       />
     </v-list-item>
-    <v-list-item>
+    <v-list-item class="mb-4">
       <v-btn prepend-icon="mdi-plus">
-          New Observable
-          <v-menu activator="parent">
-            <v-list>
-              <v-dialog v-for="typeDef in observableTypes" :width="editWidth" :fullscreen="fullScreenEdit">
-                <template v-slot:activator="{ props }">
-                  <v-list-item v-bind="props"> {{ typeDef.name }} </v-list-item>
-                </template>
-                <template v-slot:default="{ isActive }">
-                  <new-object
-                    :object-type="typeDef.type"
-                    @close="isActive.value = false"
-                    @toggle-fullscreen="toggleNewObjectFullscreen"
-                  />
-                </template>
-              </v-dialog>
-            </v-list>
-          </v-menu>
-        </v-btn>
-      </v-list-item>
+        New Observable
+        <v-menu activator="parent">
+          <v-list>
+            <v-dialog v-for="typeDef in observableTypes" :width="editWidth" :fullscreen="fullScreenEdit">
+              <template v-slot:activator="{ props }">
+                <v-list-item v-bind="props"> {{ typeDef.name }} </v-list-item>
+              </template>
+              <template v-slot:default="{ isActive }">
+                <new-object
+                  :object-type="typeDef.type"
+                  @close="isActive.value = false"
+                  @toggle-fullscreen="toggleNewObjectFullscreen"
+                />
+              </template>
+            </v-dialog>
+          </v-list>
+        </v-menu>
+      </v-btn>
+    </v-list-item>
     <v-divider></v-divider>
     <v-expansion-panels>
       <v-expansion-panel title="Bulk actions" @group:selected="showSelect = $event.value">

--- a/src/views/ObservableSearch.vue
+++ b/src/views/ObservableSearch.vue
@@ -54,6 +54,27 @@
         class="mt-2"
       />
     </v-list-item>
+    <v-list-item>
+      <v-btn prepend-icon="mdi-plus">
+          New Observable
+          <v-menu activator="parent">
+            <v-list>
+              <v-dialog v-for="typeDef in observableTypes" :width="editWidth" :fullscreen="fullScreenEdit">
+                <template v-slot:activator="{ props }">
+                  <v-list-item v-bind="props" :prepend-icon="typeDef.icon"> {{ typeDef.name }} </v-list-item>
+                </template>
+                <template v-slot:default="{ isActive }">
+                  <new-object
+                    :object-type="typeDef.type"
+                    @close="isActive.value = false"
+                    @toggle-fullscreen="toggleNewObjectFullscreen"
+                  />
+                </template>
+              </v-dialog>
+            </v-list>
+          </v-menu>
+        </v-btn>
+      </v-list-item>
     <v-divider></v-divider>
     <v-expansion-panels>
       <v-expansion-panel title="Bulk actions" @group:selected="showSelect = $event.value">
@@ -86,6 +107,9 @@
 <script lang="ts" setup>
 import axios from "axios";
 import moment from "moment";
+import { OBSERVABLE_TYPES } from "@/definitions/observableDefinitions.js";
+import NewObject from "@/components/NewObject.vue";
+
 import _ from "lodash";
 </script>
 
@@ -94,6 +118,7 @@ export default {
   data() {
     return {
       items: [],
+      observableTypes: OBSERVABLE_TYPES,
       headers: [
         { title: "Value", key: "value" },
         { title: "Tags", key: "tags", width: "300px" },
@@ -109,7 +134,10 @@ export default {
       selectedObservables: [],
       bulkTags: [],
       exportTemplates: [],
-      selectedExportTemplate: null
+      selectedExportTemplate: null,
+      fullScreenEdit: false,
+      editWidth: "50%",
+      newDialogActive: false
     };
   },
   methods: {
@@ -208,6 +236,10 @@ export default {
         .catch(error => {
           console.log(error);
         });
+    },
+    toggleNewObjectFullscreen(fullscreen: boolean) {
+      this.fullScreenEdit = !this.fullScreenEdit;
+      this.editWidth = fullscreen ? "100%" : "50%";
     }
   },
   mounted() {

--- a/src/views/ObservableSearch.vue
+++ b/src/views/ObservableSearch.vue
@@ -61,7 +61,7 @@
             <v-list>
               <v-dialog v-for="typeDef in observableTypes" :width="editWidth" :fullscreen="fullScreenEdit">
                 <template v-slot:activator="{ props }">
-                  <v-list-item v-bind="props" :prepend-icon="typeDef.icon"> {{ typeDef.name }} </v-list-item>
+                  <v-list-item v-bind="props"> {{ typeDef.name }} </v-list-item>
                 </template>
                 <template v-slot:default="{ isActive }">
                   <new-object


### PR DESCRIPTION
This PR adds `New Observable` button in observable view like it's already implemented under Indicator and Entities views.

When clicking on the button, all observables types list is rendered and when clicking on one observable type it will render a new modal window containing fields to provide. Once saved, user is redirected to the newly created observable.

![Screenshot 2024-01-22 at 10 51 07](https://github.com/yeti-platform/yeti-feeds-frontend/assets/1006203/abe37cef-3773-4bae-b5aa-93069208606e)
![Screenshot 2024-01-22 at 10 51 18](https://github.com/yeti-platform/yeti-feeds-frontend/assets/1006203/c0346522-73f1-4e48-991c-c6757a1879b1)
![Screenshot 2024-01-22 at 10 51 57](https://github.com/yeti-platform/yeti-feeds-frontend/assets/1006203/761ab17c-37a0-45c3-b022-67ea63aea1e0)
![Screenshot 2024-01-22 at 10 52 50](https://github.com/yeti-platform/yeti-feeds-frontend/assets/1006203/02154bbd-2146-4409-9be2-6096348fad50)
