### PR TITLE
Show link type when there's no description. Add information icon only…

### DIFF
--- a/src/components/RelatedObjects.vue
+++ b/src/components/RelatedObjects.vue
@@ -21,12 +21,12 @@
             <v-icon v-if="node.direction == 'out'">mdi-arrow-right</v-icon>
             <v-icon v-else-if="node.direction == 'in'">mdi-arrow-left</v-icon>
 
-            <v-btn size="small" variant="text" append-icon="mdi-information" v-if="node.description">
+            <v-btn size="small" variant="text" append-icon="mdi-information">
               <template v-slot:append>
-                <v-icon class="on-surface"></v-icon>
+                <v-icon class="on-surface" v-if="node.description"></v-icon>
               </template>
               {{ node.type }}
-              <v-menu activator="parent">
+              <v-menu activator="parent" v-if="node.description">
                 <v-sheet class="px-5 py-2" color="background" width="auto" elevation="10" style="font-size: 0.8rem">
                   <yeti-markdown :text="node.description" />
                 </v-sheet>


### PR DESCRIPTION
Show link type when there's no description. Add information icon only when description

When there is a description, information icon is appended to link type and the button is clickable to see the description's content: 

![Screenshot 2024-01-29 at 10 30 54](https://github.com/yeti-platform/yeti-feeds-frontend/assets/1006203/eee4f9c3-8061-4672-839c-d122edf17b86)

When there's no description, only displays the link type with disabled button and without information icon.

![Screenshot 2024-01-29 at 10 30 31](https://github.com/yeti-platform/yeti-feeds-frontend/assets/1006203/0f2c414f-a0c9-41d6-bbdc-a50b2755ce26)
