### PR TITLE
Private definitions

### DIFF
--- a/src/definitions/entityDefinitions.js
+++ b/src/definitions/entityDefinitions.js
@@ -429,3 +429,5 @@ export const ENTITY_TYPES = [
     icon: "mdi-medical-bag"
   }
 ];
+
+import("@/definitions/private/privateEntityDefinitions.js").catch(e => Promise.reject("Module " + modulePath + " not found.")).then(module => { ENTITY_TYPES.push(...module.ENTITY_TYPES); })

--- a/src/definitions/indicatorDefinitions.js
+++ b/src/definitions/indicatorDefinitions.js
@@ -250,3 +250,5 @@ export const INDICATOR_TYPES = [
     icon: "mdi-xml"
   }
 ];
+
+import("@/definitions/private/privateIndicatorDefinitions.js").catch(e => Promise.reject("Module " + modulePath + " not found.")).then(module => { INDICATOR_TYPES.push(...module.INDICATOR_TYPES); })

--- a/src/definitions/observableDefinitions.js
+++ b/src/definitions/observableDefinitions.js
@@ -288,3 +288,4 @@ export const OBSERVABLE_TYPES = [
     icon: "mdi-bank"
   }
 ];
+import("@/definitions/private/privateObservableDefinitions.js").catch(e => Promise.reject("Module " + modulePath + " not found.")).then(module => { OBSERVABLE_TYPES.push(...module.OBSERVABLE_TYPES); })

--- a/src/definitions/private/.gitignore
+++ b/src/definitions/private/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!README.md
+!*.sample

--- a/src/definitions/private/README.md
+++ b/src/definitions/private/README.md
@@ -1,0 +1,2 @@
+### Private definitions
+This directory is where you should place your private definitions when extending your model. It could be named anything else, but this one has a `.gitignore` so you don't mess things up. ;-)

--- a/src/definitions/private/privateEntityDefinitions.js.sample
+++ b/src/definitions/private/privateEntityDefinitions.js.sample
@@ -1,0 +1,34 @@
+export const ENTITY_TYPES = [
+    {
+        name: "PrivateEntity",
+        type: "private_entity",
+        fields: [
+          {
+            field: "created",
+            type: "date",
+            label: "Created",
+            displayList: true,
+            editable: false,
+            sortable: true,
+            width: "200px"
+          },
+          { field: "first_seen", type: "date", label: "First seen", displayList: true, editable: true, sortable: true, width: "200px" },
+          { field: "last_seen", type: "date", label: "Last seen", displayList: true, editable: true, sortable: true, width: "200px" },
+          {
+            field: "name",
+            type: "text",
+            label: "Name",
+            displayList: true,
+            editable: true,
+            sortable: true,
+            maxWidth: "500px"
+          },
+          { field: "tags", type: "list", label: "Tags", displayList: true, editable: false },
+          { field: "related_observables_count", type: "text", label: "Related observables", displayList: true, editable: false, sortable: true },
+          { field: "aliases", type: "list", label: "Aliases", displayList: true },
+          { field: "description", type: "longtext", label: "Description", displayList: false, editable: true },
+        ],
+        filterAliases: ["aliases"],
+        icon: "mdi-ab-testing",
+    }
+]

--- a/src/definitions/private/privateIndicatorDefinitions.js.sample
+++ b/src/definitions/private/privateIndicatorDefinitions.js.sample
@@ -1,0 +1,34 @@
+export const INDICATOR_TYPES = [
+    {
+        name: "PrivateIndicator",
+        type: "private_indicator",
+        fields: [
+          {
+            field: "created",
+            type: "date",
+            label: "Created",
+            displayList: true,
+            editable: false,
+            sortable: true,
+            width: "200px"
+          },
+          { field: "first_seen", type: "date", label: "First seen", displayList: true, editable: true, sortable: true, width: "200px" },
+          { field: "last_seen", type: "date", label: "Last seen", displayList: true, editable: true, sortable: true, width: "200px" },
+          {
+            field: "name",
+            type: "text",
+            label: "Name",
+            displayList: true,
+            editable: true,
+            sortable: true,
+            maxWidth: "500px"
+          },
+          { field: "tags", type: "list", label: "Tags", displayList: true, editable: false },
+          { field: "related_observables_count", type: "text", label: "Related observables", displayList: true, editable: false, sortable: true },
+          { field: "aliases", type: "list", label: "Aliases", displayList: true },
+          { field: "description", type: "longtext", label: "Description", displayList: false, editable: true },
+        ],
+        filterAliases: ["aliases"],
+        icon: "mdi-ab-testing",
+    }
+]

--- a/src/definitions/private/privateObservableDefinitions.js.sample
+++ b/src/definitions/private/privateObservableDefinitions.js.sample
@@ -1,0 +1,32 @@
+export const OBSERVABLE_TYPES = [
+    {
+        name: "PrivateObservable",
+        type: "private_observable",
+        fields: [
+          {
+            field: "created",
+            type: "date",
+            label: "Created",
+            displayList: true,
+            editable: false,
+            sortable: true,
+            width: "200px"
+          },
+          { field: "first_seen", type: "date", label: "First seen", displayList: true, editable: true, sortable: true, width: "200px" },
+          { field: "last_seen", type: "date", label: "Last seen", displayList: true, editable: true, sortable: true, width: "200px" },
+          {
+            field: "name",
+            type: "text",
+            label: "Name",
+            displayList: true,
+            editable: true,
+            sortable: true,
+            maxWidth: "500px"
+          },
+          { field: "tags", type: "list", label: "Tags", displayList: true, editable: false },
+          { field: "related_observables_count", type: "text", label: "Related observables", displayList: true, editable: false, sortable: true },
+        ],
+        filterAliases: ["aliases"],
+        icon: "mdi-ab-testing",
+    }
+]


### PR DESCRIPTION
This PR adds support for private definitions of Yeti schemas. Following the addition of private schemas definitions in the backend, this support is also needed in the frontend.