### PR TITLE
chore(auth): drop the unreferenced OIDC popup login flow

### DIFF
--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -25,27 +25,6 @@ export const useUserStore = defineStore("user", {
       window.location.href = authApi.OIDC_LOGIN_URL;
     },
 
-    /** Logs in through an OIDC popup, polling /auth/me until the cookie lands. */
-    async OIDCAsyncRefresh(): Promise<User> {
-      const popup = window.open(authApi.OIDC_LOGIN_URL, "OIDC Login", "width=800,height=600");
-      return new Promise((resolve, reject) => {
-        const timer = setInterval(async () => {
-          try {
-            const user = await this.userCheck();
-            popup?.close();
-            clearInterval(timer);
-            resolve(user);
-          } catch (error) {
-            // Not authenticated *yet* — keep polling until the popup is closed.
-            if (popup?.closed) {
-              clearInterval(timer);
-              reject(error);
-            }
-          }
-        }, 2000);
-      });
-    },
-
     /** Resolves with the logged-in user; rejects (and clears it) if there is none. */
     async userCheck(): Promise<User> {
       try {


### PR DESCRIPTION
Follow-up to #279, which flagged this as provably dead.

`userStore.OIDCAsyncRefresh` opened a popup at `/auth/oidc-login` and polled `/auth/me` on a 2s interval until a session appeared. Nothing called it — `Login.vue` had a wrapper for it, but that wrapper's own template never referenced it, and the wrapper itself went away with the users migration. After #279, `grep -rn OIDCAsyncRefresh src/ tests/` returns only its own definition.

The **live** OIDC path is `OIDCBrowserRedirect` (a full-page redirect from the Login page), which this doesn't touch. The backend's `POST /auth/oidc-callback-token` route — which a popup flow would need — stays where it is, in case someone wants to rebuild this deliberately.

## Checks
- Type-check ratchet holds at 317.
- `login` e2e (12 across the three browsers) still passes.
- `vite build` clean.