### PR TITLE
test(e2e): abort unmocked /api requests via a shared fixture

### DIFF
--- a/tests/e2e/edit-object.spec.ts
+++ b/tests/e2e/edit-object.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 /**
  * Covers components/EditObject.vue via the ObservableDetails view: opening the

--- a/tests/e2e/entity-details.spec.ts
+++ b/tests/e2e/entity-details.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test.describe('Entity Details', () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/e2e/entity-search.spec.ts
+++ b/tests/e2e/entity-search.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 
 /**
  * Covers views/EntitySearch.vue and the generic ObjectList it renders (one per

--- a/tests/e2e/example.spec.ts
+++ b/tests/e2e/example.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test('has title', async ({ page }) => {
   await page.goto('/');

--- a/tests/e2e/export-list.spec.ts
+++ b/tests/e2e/export-list.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 
 /**
  * Covers views/ExportList.vue, which drives export CRUD through the services/

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,0 +1,26 @@
+import { test as base } from "@playwright/test";
+
+/**
+ * Shared e2e test object. Use this instead of importing `test`/`expect`
+ * straight from "@playwright/test".
+ *
+ * It aborts any `/api/v2/**` request a spec hasn't explicitly mocked, which
+ * mirrors CI (where the Vite proxy target is unreachable and such requests
+ * fail to connect). Without it, running e2e in the dev container — where the
+ * backend *is* reachable — lets an unmocked request (e.g. the entities/
+ * indicators/dfiq searches EntitySelector fires on mount) return a real 401,
+ * which the http interceptor turns into a redirect to /login, so the view
+ * under test navigates away and its assertions flake.
+ *
+ * Playwright evaluates routes most-recently-registered first, so the specific
+ * routes a spec adds in its own beforeEach still take precedence over this
+ * catch-all.
+ */
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await page.route("**/api/v2/**", route => route.abort());
+    await use(page);
+  }
+});
+
+export { expect } from "@playwright/test";

--- a/tests/e2e/global-search.spec.ts
+++ b/tests/e2e/global-search.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 /**
  * Covers views/GlobalSearch.vue, which drives its data through

--- a/tests/e2e/group-admin.spec.ts
+++ b/tests/e2e/group-admin.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 /**
  * Covers views/GroupAdmin.vue -> GroupList (memberships-only: false) and the

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 /** Covers views/Login.vue and the auth flow through the user store. */
 

--- a/tests/e2e/new-object.spec.ts
+++ b/tests/e2e/new-object.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 /**
  * Covers components/NewObject.vue via the EntitySearch view (/entities): opening

--- a/tests/e2e/observable-details.spec.ts
+++ b/tests/e2e/observable-details.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 
 /**
  * Covers views/ObservableDetails.vue: the audit timeline, object context,

--- a/tests/e2e/observable-match.spec.ts
+++ b/tests/e2e/observable-match.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 /**
  * Covers views/ObservableMatch.vue, which drives its data through

--- a/tests/e2e/observable-search.spec.ts
+++ b/tests/e2e/observable-search.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 
 /**
  * Covers views/ObservableSearch.vue, which drives its data through the

--- a/tests/e2e/tags-admin.spec.ts
+++ b/tests/e2e/tags-admin.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 /**
  * Covers views/TagsAdmin.vue: the tags data table (v-data-table-server via

--- a/tests/e2e/user-admin.spec.ts
+++ b/tests/e2e/user-admin.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 import type { RegisteredApiKey } from "@/services/types";
 

--- a/tests/e2e/user-profile.spec.ts
+++ b/tests/e2e/user-profile.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 /** Covers views/UserProfile.vue, both for your own profile and as an admin. */
 


### PR DESCRIPTION
## Why
E2E specs are green in CI but **flake when run in the dev container**. In CI the Vite proxy target is unreachable, so any request a spec doesn't mock just fails to connect (`ECONNREFUSED`) and the app's http interceptor only shows a snackbar. In the dev container the backend *is* reachable, so an unmocked request — e.g. the entities/indicators/dfiq searches `EntitySelector` fires on mount (and `ObservableMatch` embeds it) — returns a real **401**, the interceptor redirects to `/login`, and the view under test navigates away mid-run. Result: specs that pass in CI flake locally.

## What
- Adds `tests/e2e/fixtures.ts` — a `test`/`expect` wrapper whose `page` fixture aborts any `**/api/v2/**` request a spec hasn't mocked, mirroring CI's unreachable backend.
- Points every spec at `./fixtures` instead of `@playwright/test` (one-line import swap in 15 files).

Playwright evaluates routes most-recently-registered first, and the fixture's catch-all is registered before each spec's own `beforeEach`, so a spec's specific mocks still take precedence.

## Effect
- ObservableMatch (and any spec embedding a component that fetches on mount) now runs deterministically in the dev container — no `/login` redirect, no flake.
- No behavior change in CI (unmocked requests already failed to connect there).

## Test plan
- [x] Full e2e suite in the dev container — **156 passed, 0 flaky** (previously observable-match flaked 9/9 there)
- [x] Re-ran observable-match 3× — stable

Independent of the Vite 8 upgrade (#291); based on `main`.