### PR TITLE
chore(api): regenerate api-schema for Package field changes

### DIFF
--- a/src/services/api-schema.d.ts
+++ b/src/services/api-schema.d.ts
@@ -6620,9 +6620,9 @@ export interface components {
              */
             type: "package";
             /** Version */
-            version?: string;
-            /** Regitry Type */
-            regitry_type?: string;
+            version?: string | null;
+            /** Registry Type */
+            registry_type?: string | null;
         };
         /** Package */
         "Package-Output": {
@@ -6662,9 +6662,9 @@ export interface components {
              */
             type: "package";
             /** Version */
-            version?: string;
-            /** Regitry Type */
-            regitry_type?: string;
+            version?: string | null;
+            /** Registry Type */
+            registry_type?: string | null;
             /** Id */
             readonly id: string;
             /** Acls */


### PR DESCRIPTION
## What

Regenerates `src/services/api-schema.d.ts` to sync with two merged backend changes to the `Package` observable:

- **yeti-platform/yeti#1300** — `Package.version` and `Package.registry_type` are now nullable (`str | None`), so the generated types change from `string` to `string | null`.
- **yeti-platform/yeti#1301** — the misspelled `regitry_type` field was renamed to `registry_type`.

## How

Regenerated with `openapi-typescript` (7.13.0, the pinned version) against the current backend `/openapi.json`. The **only** diff is those two fields on `Package-Input` / `Package-Output` (6 lines):

```
-            version?: string;
-            regitry_type?: string;
+            version?: string | null;
+            registry_type?: string | null;
```

No source code referenced the old `regitry_type` field, so nothing else needed to change.

## Verification
- `npm run typecheck` (vue-tsc ratchet) → `current=0, baseline=0` — no new type errors.