### PR TITLE
Fix stale search results and stuck type-picker menus on object list pages

### DIFF
--- a/src/components/ObjectList.vue
+++ b/src/components/ObjectList.vue
@@ -14,7 +14,6 @@
       density="compact"
       :items="items"
       @update:options="loadObjects"
-      :search="searchQuery"
       :item-value="item => item.id"
       hover
       :sort-by="sortBy"
@@ -80,7 +79,7 @@
 
 <script setup lang="ts">
 import moment from "moment";
-import { ref } from "vue";
+import { ref, watch } from "vue";
 
 import * as objectsApi from "@/services/objects";
 import type { LooseYetiObject } from "@/services/types";
@@ -95,6 +94,13 @@ const props = withDefaults(
     /** [alias, fieldType] pairs the backend widens the search with. */
     filterAliases?: Array<[string, string]>;
     checkable?: boolean;
+    /**
+     * Bump this (e.g. a counter) to force a reload with the current
+     * searchQuery. Needed because re-submitting the *same* search text is a
+     * no-op as far as Vue's reactivity is concerned -- nothing here would
+     * otherwise notice and re-fetch.
+     */
+    searchTrigger?: number;
   }>(),
   {
     searchQuery: "",
@@ -106,7 +112,8 @@ const props = withDefaults(
       { title: "Created on", key: "created", width: "200px" }
     ],
     filterAliases: () => [],
-    checkable: false
+    checkable: false,
+    searchTrigger: 0
   }
 );
 
@@ -181,6 +188,14 @@ async function loadObjects({ page: requestedPage, itemsPerPage, sortBy: requeste
     loading.value = false;
   }
 }
+
+watch(
+  () => props.searchTrigger,
+  () => {
+    page.value = 1;
+    loadObjects({ page: 1, itemsPerPage: perPage.value, sortBy: sortBy.value });
+  }
+);
 </script>
 
 

--- a/src/views/DFIQSearch.vue
+++ b/src/views/DFIQSearch.vue
@@ -42,7 +42,7 @@
     <v-list-item>
       <v-btn prepend-icon="mdi-plus">
         New DFIQ object
-        <v-menu activator="parent" v-model="newMenuOpen">
+        <v-menu activator="parent" v-model="newMenuOpen" eager>
           <v-list>
             <v-dialog v-for="typeDef in DFIQTypes" :width="editWidth" :fullscreen="fullScreenEdit">
               <template v-slot:activator="{ props }">

--- a/src/views/DFIQSearch.vue
+++ b/src/views/DFIQSearch.vue
@@ -17,6 +17,7 @@
           searchType="dfiq"
           :search-subtype="typeDef.type"
           :search-query="searchQuery"
+          :search-trigger="searchTrigger"
           :headers="getFieldForType(typeDef.type)"
           :filter-aliases="getAliasesForType(typeDef.type)"
           @totalUpdated="countDFIQ(typeDef.type, $event)"
@@ -34,18 +35,20 @@
         density="compact"
         class="mt-2"
         hint="s1007, dfiq_tags=malware, created>2024-01-01"
-        @click:prepend-innder="() => (searchQuery = searchQueryLocal)"
-        @keyup.enter="() => (searchQuery = searchQueryLocal)"
+        @click:prepend-inner="() => { searchQuery = searchQueryLocal; searchTrigger++; }"
+        @keyup.enter="() => { searchQuery = searchQueryLocal; searchTrigger++; }"
       />
     </v-list-item>
     <v-list-item>
       <v-btn prepend-icon="mdi-plus">
         New DFIQ object
-        <v-menu activator="parent">
+        <v-menu activator="parent" v-model="newMenuOpen">
           <v-list>
             <v-dialog v-for="typeDef in DFIQTypes" :width="editWidth" :fullscreen="fullScreenEdit">
               <template v-slot:activator="{ props }">
-                <v-list-item v-bind="props" :prepend-icon="typeDef.icon"> {{ typeDef.name }} </v-list-item>
+                <v-list-item v-bind="props" @click="newMenuOpen = false" :prepend-icon="typeDef.icon">
+                  {{ typeDef.name }}
+                </v-list-item>
               </template>
               <template v-slot:default="{ isActive }">
                 <edit-DFIQ-object
@@ -74,6 +77,8 @@ const DFIQTypes = DFIQ_TYPES;
 
 const searchQuery = ref("");
 const searchQueryLocal = ref("");
+const searchTrigger = ref(0);
+const newMenuOpen = ref(false);
 
 const {
   counts: DFIQCount,

--- a/src/views/EntitySearch.vue
+++ b/src/views/EntitySearch.vue
@@ -42,7 +42,7 @@
     <v-list-item>
       <v-btn prepend-icon="mdi-plus">
         New Entity
-        <v-menu activator="parent" v-model="newMenuOpen">
+        <v-menu activator="parent" v-model="newMenuOpen" eager>
           <v-list>
             <v-dialog v-for="typeDef in entityTypes" :width="editWidth" :fullscreen="fullScreenEdit">
               <template v-slot:activator="{ props }">

--- a/src/views/EntitySearch.vue
+++ b/src/views/EntitySearch.vue
@@ -17,6 +17,7 @@
           searchType="entities"
           :search-subtype="typeDef.type"
           :search-query="searchQuery"
+          :search-trigger="searchTrigger"
           :headers="getFieldForType(typeDef.type)"
           :filter-aliases="getAliasesForType(typeDef.type)"
           @totalUpdated="countEntities(typeDef.type, $event)"
@@ -34,18 +35,20 @@
         density="compact"
         class="mt-2"
         hint="e.g. created>2024-01-01, family=miner, tags=malware"
-        @click:prepend-innder="() => (searchQuery = searchQueryLocal)"
-        @keyup.enter="() => (searchQuery = searchQueryLocal)"
+        @click:prepend-inner="() => { searchQuery = searchQueryLocal; searchTrigger++; }"
+        @keyup.enter="() => { searchQuery = searchQueryLocal; searchTrigger++; }"
       />
     </v-list-item>
     <v-list-item>
       <v-btn prepend-icon="mdi-plus">
         New Entity
-        <v-menu activator="parent">
+        <v-menu activator="parent" v-model="newMenuOpen">
           <v-list>
             <v-dialog v-for="typeDef in entityTypes" :width="editWidth" :fullscreen="fullScreenEdit">
               <template v-slot:activator="{ props }">
-                <v-list-item v-bind="props" :prepend-icon="typeDef.icon"> {{ typeDef.name }} </v-list-item>
+                <v-list-item v-bind="props" @click="newMenuOpen = false" :prepend-icon="typeDef.icon">
+                  {{ typeDef.name }}
+                </v-list-item>
               </template>
               <template v-slot:default="{ isActive }">
                 <new-object
@@ -73,6 +76,8 @@ const entityTypes = ENTITY_TYPES;
 
 const searchQuery = ref("");
 const searchQueryLocal = ref("");
+const searchTrigger = ref(0);
+const newMenuOpen = ref(false);
 
 const {
   counts: entityCount,

--- a/src/views/IndicatorSearch.vue
+++ b/src/views/IndicatorSearch.vue
@@ -42,7 +42,7 @@
     <v-list-item>
       <v-btn prepend-icon="mdi-plus">
         New Indicator
-        <v-menu activator="parent" v-model="newMenuOpen">
+        <v-menu activator="parent" v-model="newMenuOpen" eager>
           <v-list>
             <v-dialog v-for="typeDef in indicatorTypes" :width="editWidth" :fullscreen="fullScreenEdit">
               <template v-slot:activator="{ props }">

--- a/src/views/IndicatorSearch.vue
+++ b/src/views/IndicatorSearch.vue
@@ -17,6 +17,7 @@
           searchType="indicators"
           :search-subtype="typeDef.type"
           :search-query="searchQuery"
+          :search-trigger="searchTrigger"
           :headers="getFieldForType(typeDef.type)"
           :filter-aliases="getAliasesForType(typeDef.type)"
           @totalUpdated="countIndicators(typeDef.type, $event)"
@@ -34,18 +35,20 @@
         density="compact"
         class="mt-2"
         hint="e.g. created>2024-01-01, supported_os=windows"
-        @click:prepend-inner="() => (searchQuery = searchQueryLocal)"
-        @keyup.enter="() => (searchQuery = searchQueryLocal)"
+        @click:prepend-inner="() => { searchQuery = searchQueryLocal; searchTrigger++; }"
+        @keyup.enter="() => { searchQuery = searchQueryLocal; searchTrigger++; }"
       />
     </v-list-item>
     <v-list-item>
       <v-btn prepend-icon="mdi-plus">
         New Indicator
-        <v-menu activator="parent">
+        <v-menu activator="parent" v-model="newMenuOpen">
           <v-list>
             <v-dialog v-for="typeDef in indicatorTypes" :width="editWidth" :fullscreen="fullScreenEdit">
               <template v-slot:activator="{ props }">
-                <v-list-item v-bind="props" :prepend-icon="typeDef.icon"> {{ typeDef.name }} </v-list-item>
+                <v-list-item v-bind="props" @click="newMenuOpen = false" :prepend-icon="typeDef.icon">
+                  {{ typeDef.name }}
+                </v-list-item>
               </template>
               <template v-slot:default="{ isActive }">
                 <new-object
@@ -73,6 +76,8 @@ const indicatorTypes = INDICATOR_TYPES;
 
 const searchQuery = ref("");
 const searchQueryLocal = ref("");
+const searchTrigger = ref(0);
+const newMenuOpen = ref(false);
 
 const {
   counts: indicatorCount,

--- a/src/views/ObservableSearch.vue
+++ b/src/views/ObservableSearch.vue
@@ -63,7 +63,7 @@
     <v-list-item class="mb-4">
       <v-btn prepend-icon="mdi-plus">
         New Observable
-        <v-menu activator="parent" v-model="newMenuOpen">
+        <v-menu activator="parent" v-model="newMenuOpen" eager>
           <v-list>
             <v-dialog v-for="typeDef in observableTypes" :key="typeDef.type" :width="editWidth" :fullscreen="fullScreenEdit">
               <template v-slot:activator="{ props }">

--- a/src/views/ObservableSearch.vue
+++ b/src/views/ObservableSearch.vue
@@ -63,11 +63,11 @@
     <v-list-item class="mb-4">
       <v-btn prepend-icon="mdi-plus">
         New Observable
-        <v-menu activator="parent">
+        <v-menu activator="parent" v-model="newMenuOpen">
           <v-list>
             <v-dialog v-for="typeDef in observableTypes" :key="typeDef.type" :width="editWidth" :fullscreen="fullScreenEdit">
               <template v-slot:activator="{ props }">
-                <v-list-item v-bind="props"> {{ typeDef.name }} </v-list-item>
+                <v-list-item v-bind="props" @click="newMenuOpen = false"> {{ typeDef.name }} </v-list-item>
               </template>
               <template v-slot:default="{ isActive }">
                 <new-object
@@ -152,6 +152,7 @@ const exportTemplates = ref<Template[]>([]);
 const selectedExportTemplate = ref<string | null>(null);
 const fullScreenEdit = ref(false);
 const editWidth = ref("50%");
+const newMenuOpen = ref(false);
 const sortBy = ref<SortItem[]>([{ key: "created", order: "desc" }]);
 
 /** The distinct context sources on an observable, for the chips column. */


### PR DESCRIPTION
## Summary
Three real, if minor, bugs found while building yeti-docker's real-backend integration E2E suite (yeti-platform/yeti-docker#32):

- **Entities/Indicators/DFIQ search silently no-ops on a repeated, unchanged query.** `ObjectList.vue` relied solely on `v-data-table-server`'s own `search` prop reactivity to trigger a refetch, which Vuetify only re-evaluates when the *value* actually changes (confirmed in Vuetify's own `VDataTable/composables/options.js`). Re-pressing Enter with the same text -- e.g. retrying a search right after tagging something, before the ArangoSearch view catches up -- did nothing, with no visible feedback that the app hadn't even tried. `ObservableSearch.vue` never had this bug because it explicitly calls `loadObjects()` on Enter instead of relying on prop-change detection. Fixed by giving `ObjectList.vue` an explicit `searchTrigger` counter prop that forces a reload independent of whether the text changed.
- **The "New Entity/Indicator/DFIQ/Observable" type-picker menu never closes when a type's create dialog opens.** The `v-menu` wrapping the per-type `v-dialog` activators had no explicit close signal, so it stayed an active overlay stacked behind the dialog (confirmed via DOM inspection: `v-overlay--active.v-menu` count stayed at 1 after opening the dialog). Fixed by giving each menu an explicit `v-model` and closing it alongside the dialog's own click-to-open action.
- **`@click:prepend-innder` typo** (EntitySearch, DFIQSearch) silently disabled the search icon's click handler -- only Enter worked on those two pages. Indicators already had it spelled correctly.

## Test plan
- [x] `npm run typecheck` -- ratchet baseline holds at 0 new errors.
- [x] Verified both fixes against the real dev stack (not just mocked/unit tests) using Playwright with request/DOM instrumentation:
  - Menu-close: active `v-menu` overlay count goes from 1 (menu open) to 0 (after opening the create dialog) -- previously stayed at 1.
  - Search-refresh: a second Enter press with unchanged search text now re-fires every visible tab's search request (11 for Entities, 6 for Indicators, 3 for DFIQ) -- previously fired 0 requests.
- [ ] CI (typecheck/lint/build) on this branch.
