### PR TITLE
Fix hash deep-link tab race and EntitySelector option a11y/routing bugs

### DIFF
--- a/src/components/EntitySelector.vue
+++ b/src/components/EntitySelector.vue
@@ -103,11 +103,6 @@ const DETAILS_ROUTE_BY_ROOT_TYPE: Record<string, string> = {
   dfiq: "DFIQDetails"
 };
 
-/**
- * The "details" link always pointed at EntityDetails regardless of the
- * result's actual root_type (this selector lists entities, indicators, and
- * dfiq objects together) -- route by the real type instead.
- */
 function detailsRouteName(rootType: string): string {
   return DETAILS_ROUTE_BY_ROOT_TYPE[rootType] ?? "EntityDetails";
 }

--- a/src/components/EntitySelector.vue
+++ b/src/components/EntitySelector.vue
@@ -28,21 +28,29 @@
     </template>
 
     <template v-slot:item="{ props, item }">
-      <v-list-item :prepend-icon="getIconForType(item.type)">
-        <div class="d-flex">
-          <v-btn variant="text" v-bind="props">{{ item.name }}</v-btn>
-          <v-spacer></v-spacer>
+      <!--
+        v-bind="props" goes on this v-list-item itself, not a button nested
+        inside it: Vuetify assigns role="option" to this element regardless
+        of where the click/selection props are bound, so binding them here
+        keeps the whole option's accessible role and its actual click
+        behavior on the same element instead of splitting them across a
+        wrapper + an inner button (which also meant two separately
+        focusable controls -- name and "details" -- inside a single
+        announced option).
+      -->
+      <v-list-item v-bind="props" :prepend-icon="getIconForType(item.type)">
+        <template v-slot:append>
           <v-btn
             variant="text"
-            :to="{ name: 'EntityDetails', params: { id: item.id } }"
+            :to="{ name: detailsRouteName(item.root_type), params: { id: item.id } }"
             target="_blank"
             prepend-icon="mdi-open-in-new"
             size="x-small"
             rounded="sm"
-            class="mt-2"
+            @click.stop
             >details</v-btn
           >
-        </div>
+        </template>
       </v-list-item>
     </template>
   </v-autocomplete>
@@ -88,6 +96,21 @@ const getHintForTypes = computed(() =>
     ? `Filtering for ${props.typeFilter.join(", ")}`
     : "Filtering for all object types"
 );
+
+const DETAILS_ROUTE_BY_ROOT_TYPE: Record<string, string> = {
+  entity: "EntityDetails",
+  indicator: "IndicatorDetails",
+  dfiq: "DFIQDetails"
+};
+
+/**
+ * The "details" link always pointed at EntityDetails regardless of the
+ * result's actual root_type (this selector lists entities, indicators, and
+ * dfiq objects together) -- route by the real type instead.
+ */
+function detailsRouteName(rootType: string): string {
+  return DETAILS_ROUTE_BY_ROOT_TYPE[rootType] ?? "EntityDetails";
+}
 
 async function loadObjects(searchQuery = "") {
   const request = { query: { name: searchQuery }, count: 20 };

--- a/src/views/ObjectDetails.vue
+++ b/src/views/ObjectDetails.vue
@@ -398,6 +398,16 @@ async function saveTags() {
 
 function countObjects(key: string, value: number) {
   relatedObjectTabCount.value[key] = value;
+  // Entity-type tabs are conditionally rendered (displayedEntityTypes only
+  // includes types with count > 0), so a hash-targeted entity-type tab
+  // doesn't exist yet at mount time -- v-tabs/v-window silently fall back
+  // to another tab for a v-model value with no matching, currently-rendered
+  // tab. Once this key's count arrives and matches the hash, the tab now
+  // exists: re-assert the selection to recover from that fallback.
+  if (route.hash === `#${key}` && value > 0) {
+    activeTab.value = `related-${key}`;
+    return;
+  }
   if (!route.hash && autoTab.value) {
     navigateToFirstPopulatedTab();
   }

--- a/src/views/ObjectDetails.vue
+++ b/src/views/ObjectDetails.vue
@@ -399,11 +399,9 @@ async function saveTags() {
 function countObjects(key: string, value: number) {
   relatedObjectTabCount.value[key] = value;
   // Entity-type tabs are conditionally rendered (displayedEntityTypes only
-  // includes types with count > 0), so a hash-targeted entity-type tab
-  // doesn't exist yet at mount time -- v-tabs/v-window silently fall back
-  // to another tab for a v-model value with no matching, currently-rendered
-  // tab. Once this key's count arrives and matches the hash, the tab now
-  // exists: re-assert the selection to recover from that fallback.
+  // includes types with count > 0), so a hash-targeted entity-type tab may
+  // not exist yet when this count arrives -- (re-)assert the selection now
+  // that it does.
   if (route.hash === `#${key}` && value > 0) {
     activeTab.value = `related-${key}`;
     return;

--- a/tests/e2e/observable-details.spec.ts
+++ b/tests/e2e/observable-details.spec.ts
@@ -179,8 +179,6 @@ test.describe("Observable Details", () => {
     // The dialog's first input is the "filter on suggested types" checkbox, so
     // target the text inputs; the EntitySelector autocomplete is the first.
     await dialog.locator('input[type="text"]').first().click();
-    // Each result is a v-list-item that itself carries role="option" (not a
-    // button inside it).
     await page.getByRole("option", { name: "EvilCorp" }).click();
 
     await dialog.getByRole("button", { name: "Save" }).click();

--- a/tests/e2e/observable-details.spec.ts
+++ b/tests/e2e/observable-details.spec.ts
@@ -179,7 +179,9 @@ test.describe("Observable Details", () => {
     // The dialog's first input is the "filter on suggested types" checkbox, so
     // target the text inputs; the EntitySelector autocomplete is the first.
     await dialog.locator('input[type="text"]').first().click();
-    await page.getByRole("button", { name: "EvilCorp" }).first().click();
+    // Each result is a v-list-item that itself carries role="option" (not a
+    // button inside it).
+    await page.getByRole("option", { name: "EvilCorp" }).click();
 
     await dialog.getByRole("button", { name: "Save" }).click();
 


### PR DESCRIPTION
## Summary
Two real bugs found while building yeti-docker's integration test suite (#33, #34), both confirmed with direct console instrumentation before fixing, not assumed.

**1. `ObjectDetails.vue`: hash deep-links to an entity-type tab land on the wrong tab on a cold page load.** E.g. `/indicators/123#malware` doesn't select the Malware tab. Root cause: entity-type tabs are conditionally rendered (`displayedEntityTypes` only includes types with a nonzero neighbor count), so at the moment the hash-based selection runs, the target tab doesn't exist in the DOM yet -- `v-tabs`/`v-window` silently falls back to another tab for a `v-model` value with no matching rendered tab, and nothing re-applies the hash once the real tab actually appears a moment later (once its count arrives). Fixed by re-asserting the tab selection in `countObjects()` once that specific tab's count arrives and matches the current hash.

**2. `EntitySelector.vue`: each search result nests two separately-focusable buttons inside one `role="option"`.** Vuetify assigns `role="option"` to the `v-list-item` itself regardless of where the actual click/selection props are bound -- they were bound to an *inner* "name" button instead, with a separate "details" button as a sibling. A screen reader announces one option but there are two independently activatable controls inside it (an ARIA anti-pattern), and it also made accessible-name matching against the option unreliable (the whole reason yeti-docker#33's integration spec needed a `[role="option"]` + `hasText` workaround instead of a plain name match). Fixed by binding `props` to the `v-list-item` itself and marking the details link non-propagating (`@click.stop`). Also fixed a latent bug in the same block while in there: the "details" link always pointed at `EntityDetails` regardless of the result's actual `root_type` (this selector lists entities, indicators, and dfiq together) -- now routes by the real type.

The `EntitySelector` fix required updating one of the frontend's own mocked e2e tests (`observable-details.spec.ts`), which asserted against the old button-based structure.

## Test plan
- [x] `npm run typecheck` -- ratchet baseline holds at 0.
- [x] Verified both fixes live against the real dev stack (not just type-checked): the hash-race fix lands on the correct tab with the real neighbor row across 3 repeated fresh-stack runs; the EntitySelector fix makes the plain `getByRole("option", { name })` locator match and select correctly (previously required the `[role="option"]` workaround).
- [x] Full local e2e suite (`npx playwright test`) -- 52/52 pass, including the updated `observable-details.spec.ts` spec.
