### PR TITLE
Fix missing EditDFIQObject import breaking all DFIQ object creation

### DIFF
--- a/src/components/DFIQ/EditDFIQObject.vue
+++ b/src/components/DFIQ/EditDFIQObject.vue
@@ -535,7 +535,7 @@ export default {
     },
     // Matches Vuetify's FilterFunction signature: (value, query, item?).
     parentSearchFilter(itemTitle: string, queryText: string, item?: { raw: LooseYetiObject }): boolean {
-      const inId = !!item?.raw.dfiq_id.toLowerCase().includes(queryText.toLowerCase());
+      const inId = !!item?.raw.dfiq_id?.toLowerCase().includes(queryText.toLowerCase());
       const inTitle = itemTitle.toLowerCase().includes(queryText.toLowerCase());
       return inId || inTitle;
     },

--- a/src/views/DFIQSearch.vue
+++ b/src/views/DFIQSearch.vue
@@ -67,7 +67,7 @@
 </template>
 
 <script setup lang="ts">
-import NewObject from "@/components/NewObject.vue";
+import EditDFIQObject from "@/components/DFIQ/EditDFIQObject.vue";
 import ObjectList from "@/components/ObjectList.vue";
 import { useTypeTabs } from "@/composables/useTypeTabs";
 import { DFIQ_TYPES } from "@/definitions/dfiqDefinitions";


### PR DESCRIPTION
## Summary
`DFIQSearch.vue`'s "New DFIQ object" menu template uses `<edit-DFIQ-object>` for every type (Scenario/Facet/Question), but the component was never imported in the file's `<script setup>` block. Vue couldn't resolve the tag, so the create dialog rendered as an empty, non-functional overlay for **every** DFIQ type -- creating a new top-level Scenario, Facet, or Question from `/dfiq` was completely broken. Confirmed by inspecting the actual rendered DOM: the dialog's content was literally `<edit-dfiq-object ...></edit-dfiq-object>`, an unresolved custom element with no children.

Also removed the unused `NewObject` import from the same file -- DFIQ objects always go through `EditDFIQObject`'s YAML-backed create/validate flow, never the generic `NewObject.vue` (that import was dead weight, likely left over from before DFIQ got its own creation flow).

Found while building yeti-docker's new DFIQ integration specs (add a scenario / add a scenario + inline question / associate a question with two scenarios via "Parents") -- the very first spec couldn't get past creating a scenario at all until this was fixed.

## Test plan
- [x] `npm run typecheck` -- ratchet baseline holds at 0.
- [x] Verified live against the real dev stack: creating a Scenario now opens a working dialog, saves, and redirects to `/dfiq/{id}` as expected.
- [x] Full local e2e suite -- 51/52 pass (the one failure is the untracked, uncommitted `agent-chat.spec.ts`, unrelated to this change).
- [x] All 3 new DFIQ integration specs (yeti-docker, separate PR) pass reliably against a stack built from this branch, standalone and as part of the full suite, plus a full fresh `run.sh` build.
