### PR TITLE
Fix DFIQ Parents filter silently not filtering when dfiq_id is null

### DIFF
--- a/src/components/DFIQ/EditDFIQObject.vue
+++ b/src/components/DFIQ/EditDFIQObject.vue
@@ -535,7 +535,7 @@ export default {
     },
     // Matches Vuetify's FilterFunction signature: (value, query, item?).
     parentSearchFilter(itemTitle: string, queryText: string, item?: { raw: LooseYetiObject }): boolean {
-      const inId = !!item?.raw.dfiq_id.toLowerCase().includes(queryText.toLowerCase());
+      const inId = !!item?.raw.dfiq_id?.toLowerCase().includes(queryText.toLowerCase());
       const inTitle = itemTitle.toLowerCase().includes(queryText.toLowerCase());
       return inId || inTitle;
     },


### PR DESCRIPTION
## Summary
- `parentSearchFilter` in `EditDFIQObject.vue` called `item.raw.dfiq_id.toLowerCase()` unconditionally
- DFIQ ID is an optional field and is `null` on virtually every object in practice, so typing anything into the "Parents" autocomplete field threw a `TypeError` on every keystroke inside Vuetify's filter `watchEffect`
- The thrown error aborts that reactive update, leaving the previously rendered (unfiltered) item list on screen — so the field silently appears to not filter at all

Stacked on #299 since a working DFIQ create/edit dialog is needed to reach this code path through the UI.

## Test plan
- [x] `npm run typecheck` — 0 errors, ratchet baseline holds
- [x] Reproduced live: created ~15 scenarios with `dfiq_id: null`, opened a Question's Parents field, typed a substring — before the fix, browser threw `Cannot read properties of null (reading 'toLowerCase')` on every keystroke and the list stayed unfiltered; after the fix, the list correctly narrows to matching items with no console errors
