### PR TITLE
Stop sending redundant dfiq_type; derive it from the live YAML everywhere

### DIFF
--- a/src/components/DFIQ/EditDFIQObject.vue
+++ b/src/components/DFIQ/EditDFIQObject.vue
@@ -1,13 +1,13 @@
 <template>
   <v-card>
     <v-card-title>{{ localObject.name }}</v-card-title>
-    <v-card-subtitle>{{ newType !== "" ? "Creating" : "Editing" }} DFIQ {{ localObject.type }}</v-card-subtitle>
+    <v-card-subtitle>{{ newType !== "" ? "Creating" : "Editing" }} DFIQ {{ parsedYaml.type }}</v-card-subtitle>
     <v-card-subtitle v-if="parent !== null"
       >Parent ID {{ parent.dfiq_id }} pre-populated from {{ parent.type }} "{{ parent.name }}""</v-card-subtitle
     >
     <v-card-text>
       <v-tabs v-model="activeTab" color="primary">
-        <v-tab value="user-form">{{ localObject.type }}</v-tab>
+        <v-tab value="user-form">{{ parsedYaml.type }}</v-tab>
         <v-tab v-if="parsedYaml.type === 'question'" value="approaches">Approaches</v-tab>
         <v-tab value="yaml">YAML</v-tab>
       </v-tabs>
@@ -28,7 +28,7 @@
             density="compact"
           ></v-text-field>
           <v-autocomplete
-            v-if="['question', 'facet'].includes(localObject.type)"
+            v-if="['question', 'facet'].includes(parsedYaml.type)"
             label="Parents"
             v-model="parsedYaml.parent_ids"
             :items="possibleParents"
@@ -40,7 +40,7 @@
             dense
             chips
             :custom-filter="parentSearchFilter"
-            :placeholder="`Add parents to this ${localObject.type}`"
+            :placeholder="`Add parents to this ${parsedYaml.type}`"
             persistent-placeholder
           >
             <template v-slot:item="{ props, item }">
@@ -565,7 +565,6 @@ export default {
       this.validatingYaml = "primary";
       axios
         .post(`/api/v2/dfiq/validate`, {
-          dfiq_type: this.localObject.type,
           dfiq_yaml: this.localObject.dfiq_yaml,
           check_id: this.newType !== ""
         })
@@ -581,7 +580,6 @@ export default {
     },
     createObject() {
       const createRequest = {
-        dfiq_type: this.localObject.type,
         dfiq_yaml: this.localObject.dfiq_yaml,
         update_indicators: false
       };
@@ -624,7 +622,6 @@ export default {
       }
 
       const patchRequest = {
-        dfiq_type: this.localObject.type,
         dfiq_yaml: this.localObject.dfiq_yaml,
         update_indicators: false
       };


### PR DESCRIPTION
## Summary
- `dfiq_type` was sent alongside `dfiq_yaml` on every DFIQ create/validate/patch request, duplicating the YAML body's own `type:` key. Paired backend fix (yeti-platform/yeti#1340) removes the field from the request schemas entirely (`extra="forbid"`, so this side must stop sending it or every DFIQ save breaks with a 422).
- Fixes a real, reachable UI bug the same redundancy was masking: `localObject.type` was frozen at dialog-open time and never re-derived, while the "Approaches" tab's visibility already tracked the live `parsedYaml.type`. Hand-editing the raw YAML tab's `type:` field (a first-class, unguarded editing path in this dialog) made the Approaches tab and the Parents field visibly disagree about the object's type -- then Save would fail with a confusing 400 from the backend's own (separate) type-mismatch guard. All four type-driven UI checks (subtitle, tab label, Parents field visibility, placeholder text) now consistently read `parsedYaml.type`.

## Test plan
- [x] `npm run typecheck` -- 0/0
- [x] `npm run lint:check` -- 172/172
- [x] End-to-end verified live against the paired backend fix (temporary backend instance running yeti#1340, plus a temporary secondary Vite dev server): scenario creation succeeds through the real UI with `dfiq_type` no longer sent, and toggling a Question's raw-YAML `type:` from `question` to `facet` correctly flips both the Approaches tab (disappears) and the dialog's subtitle/tab-label/Parents-field (now say "facet") in agreement -- confirming the fix for the exact disagreement described above
- [x] No new page errors during that verification run

Depends on yeti-platform/yeti#1340 landing first (or being deployed alongside) -- this frontend change alone, without the backend fix, would start sending create/edit requests missing a field the *current* backend still requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tXLywVq32tGPE7jCrdZVJ