### PR TITLE
Fix doubled /dfiq/dfiq/ path when navigating from a trailing-slash URL

### DIFF
--- a/src/components/ObjectList.vue
+++ b/src/components/ObjectList.vue
@@ -23,7 +23,7 @@
       <template v-slot:item.name="{ item }">
         <span class="short-links">
           <v-tooltip activator="parent" location="top" :open-delay="200">{{ item.name }}</v-tooltip>
-          <router-link :to="`${searchType}/${item.id}`">{{ item.name }}</router-link>
+          <router-link :to="`/${searchType}/${item.id}`">{{ item.name }}</router-link>
         </span>
       </template>
       <template v-slot:item.tags="{ item }">


### PR DESCRIPTION
## Summary
- Reported bug: visiting `/dfiq/` (trailing slash) instead of `/dfiq`, then clicking a scenario, lands on `/dfiq/dfiq/16152084` instead of `/dfiq/16152084`.
- Root cause: `ObjectList.vue`'s row link is a relative `router-link` (`` `${searchType}/${item.id}` ``, no leading slash). Vue Router resolves relative links the way a browser resolves a relative href against the current URL -- at `/dfiq` the last path segment gets replaced (correct: `/dfiq/123`), but at `/dfiq/` the path is treated as a directory and the relative target gets appended instead (`/dfiq/dfiq/123`).
- `ObjectList.vue` is shared by DFIQ, Entities, and Indicators search pages (Observables has its own separate table), so all three were affected by the same bug whenever a user landed on a trailing-slash URL, not just DFIQ.
- Fix: make the link absolute (`` `/${searchType}/${item.id}` ``), which resolves identically regardless of the current path.

## Test plan
- [x] Reproduced against a real backend: confirmed the doubled `/dfiq/dfiq/...` path with the original relative link, from `/dfiq/`
- [x] Confirmed the fix resolves it, same repro
- [x] Confirmed no regression on the previously-working case (`/dfiq`, no trailing slash)
- [x] Confirmed the same trailing-slash bug and fix on Entities (`/entities/`), since it shares this component
- [x] `npm run typecheck` -- 0/0, `npm run lint:check` -- clean
