### PR TITLE
Remove the Permission/Role type-widening workarounds

### DIFF
--- a/src/components/ACLEdit.vue
+++ b/src/components/ACLEdit.vue
@@ -98,7 +98,7 @@ import { computed, onMounted, ref, watch } from "vue";
 import { eventBus } from "@/plugins/eventbus";
 import * as groupsApi from "@/services/groups";
 import * as rbacApi from "@/services/rbac";
-import type { AclRootType, LooseYetiObject, RoleRelationship } from "@/services/types";
+import type { AclRootType, LooseYetiObject, Role, RoleRelationship } from "@/services/types";
 import * as usersApi from "@/services/users";
 
 const props = withDefaults(
@@ -140,7 +140,7 @@ const systemUsers = ref<Identity[]>([]);
 const systemGroups = ref<Identity[]>([]);
 const selectedIdentities = ref<Identity[]>([]);
 const identityListLoading = ref(false);
-const selectedRole = ref(1);
+const selectedRole = ref<Role>(1);
 
 const allIdentities = computed(() => [...systemUsers.value, ...systemGroups.value]);
 
@@ -171,9 +171,7 @@ async function getMembershipData() {
   const object = await rbacApi.acls(rootType.value, props.object.id);
   const acls: Record<string, RoleRelationship> = object.acls ?? {};
   aclTableData.value = Object.entries(acls)
-    // role is a Permission IntFlag; 0 ("no access") is a real value the
-    // generated `1 | 2 | 4` type can't express, so compare as a number.
-    .filter(([, edge]) => (edge.role as number) !== 0)
+    .filter(([, edge]) => edge.role !== 0)
     .map(([name, edge]) => ({ ...edge, name }));
 }
 

--- a/src/services/api-schema.d.ts
+++ b/src/services/api-schema.d.ts
@@ -4639,7 +4639,7 @@ export interface components {
              * @default
              */
             name: string;
-            permissions?: components["schemas"]["Permission"] | null;
+            permissions?: components["schemas"]["Role"] | null;
             /**
              * Count
              * @default 50
@@ -6719,7 +6719,7 @@ export interface components {
         PatchRoleRequest: {
             /** User Id */
             user_id: string;
-            role: components["schemas"]["Permission"];
+            role: components["schemas"]["Role"];
         };
         /** Path */
         "Path-Input": {
@@ -6809,11 +6809,6 @@ export interface components {
             /** Is Valid */
             readonly is_valid: boolean;
         };
-        /**
-         * Permission
-         * @enum {integer}
-         */
-        Permission: 1 | 2 | 4;
         /** Phone */
         "Phone-Input": {
             /**
@@ -7413,13 +7408,25 @@ export interface components {
             /** New Password */
             new_password: string;
         };
+        /**
+         * Role
+         * @description The Permission combinations actually granted over the API.
+         *
+         *     A plain int/enum (not Permission itself) so FastAPI's OpenAPI generation
+         *     -- and hence generated client types -- list exactly these four values
+         *     instead of Permission's individual flags (1, 2, 4), which don't include
+         *     the composite values (0, 3, 7) every role-granting endpoint actually
+         *     accepts.
+         * @enum {integer}
+         */
+        Role: 0 | 1 | 3 | 7;
         /** RoleRelationship */
         "RoleRelationship-Input": {
             /** Source */
             source: string;
             /** Target */
             target: string;
-            role: components["schemas"]["Permission"];
+            role: components["schemas"]["Role"];
             /**
              * Created
              * Format: date-time
@@ -7437,7 +7444,7 @@ export interface components {
             source: string;
             /** Target */
             target: string;
-            role: components["schemas"]["Permission"];
+            role: components["schemas"]["Role"];
             /**
              * Created
              * Format: date-time
@@ -8674,7 +8681,7 @@ export interface components {
             /** Ids */
             ids: components["schemas"]["RBACIdentity"][];
             /** @default 1 */
-            role: components["schemas"]["Permission"];
+            role: components["schemas"]["Role"];
         };
         /** UpdateMembersResponse */
         UpdateMembersResponse: {

--- a/src/services/rbac.ts
+++ b/src/services/rbac.ts
@@ -1,16 +1,5 @@
 import http from "@/services/http";
-import type { AclRootType, LooseYetiObject, RBACIdentity, UpdateMembersResponse } from "@/services/types";
-
-/**
- * `role` is a `Permission` IntFlag backend-side, so the generated type comes out
- * as `1 | 2 | 4` — which rejects the composite values the UI actually sends
- * (0 = no access, 1 = reader, 3 = writer, 7 = owner). Widened back to number;
- * same story as SetRoleRequest in services/users.ts.
- */
-export interface UpdateMembersRequest {
-  ids: RBACIdentity[];
-  role: number;
-}
+import type { AclRootType, LooseYetiObject, UpdateMembersRequest, UpdateMembersResponse } from "@/services/types";
 
 /**
  * The object with its ACLs resolved. The endpoint returns the object itself

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -72,12 +72,15 @@ export type DeleteApiKeyResponse = Schemas["DeleteApiKeyResponse"];
 export type RegisteredApiKey = Schemas["RegisteredApiKey"];
 
 // Groups / RBAC
+/** The only role values the API accepts: 0 = no access, 1 = read, 3 = read/write, 7 = admin. */
+export type Role = Schemas["Role"];
 export type Group = Schemas["Group-Output"];
 export type GroupInput = Schemas["Group-Input"];
 export type GroupSearchRequest = Schemas["GroupSearchRequest"];
 export type GroupSearchResponse = Schemas["GroupSearchResponse"];
 export type NewGroupRequest = Schemas["NewGroupRequest"];
 export type RBACIdentity = Schemas["RBACIdentity"];
+export type UpdateMembersRequest = Schemas["UpdateACLRequest"];
 export type UpdateMembersResponse = Schemas["UpdateMembersResponse"];
 /** One ACL edge: who (`source`) has what `role` on what (`target`). `id` is the edge's. */
 export type RoleRelationship = Schemas["RoleRelationship-Output"];

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -44,15 +44,7 @@ export async function toggle(request: ToggleUserRequest): Promise<User> {
   return data;
 }
 
-/**
- * `role` is a `Permission` IntFlag on the backend. OpenAPI can only describe the
- * individual flags, so the generated type comes out as `1 | 2 | 4` — which
- * rejects the composite values the UI actually sends (0 = no access,
- * 3 = read/write, 7 = admin). Widen it back to the number it really is.
- */
-export type SetRoleRequest = Omit<PatchRoleRequest, "role"> & { role: number };
-
-export async function setRole(request: SetRoleRequest): Promise<unknown> {
+export async function setRole(request: PatchRoleRequest): Promise<unknown> {
   const { data } = await http.patch("/users/role", request);
   return data;
 }

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -73,7 +73,7 @@ import { computed, onMounted, ref, watch } from "vue";
 import ApiKeyManagement from "@/components/ApiKeyManagement.vue";
 import GroupList from "@/components/GroupList.vue";
 import { eventBus } from "@/plugins/eventbus";
-import type { User } from "@/services/types";
+import type { Role, User } from "@/services/types";
 import * as usersApi from "@/services/users";
 import { useAppStore } from "@/store/app";
 import { useUserStore } from "@/store/user";
@@ -130,7 +130,10 @@ async function updateUserRole() {
   if (!profile.value) {
     return;
   }
-  await usersApi.setRole({ user_id: profile.value.id, role: profile.value.global_role });
+  // global_role is stored as a plain int server-side (it can theoretically hold
+  // any composite Permission value), but roleMapping only ever offers one of
+  // Role's four -- safe to narrow here.
+  await usersApi.setRole({ user_id: profile.value.id, role: profile.value.global_role as Role });
   eventBus.emit("displayMessage", { message: "Settings successfully updated.", status: "success" });
 }
 


### PR DESCRIPTION
## Summary
- Backend (yeti-platform/yeti#1342) now exposes `Role`'s real value set (`0 | 1 | 3 | 7`) in the generated OpenAPI schema, instead of `Permission`'s individual flags (`1 | 2 | 4`).
- Removes the manual type-widening this frontend carried around that gap: `SetRoleRequest` in `services/users.ts`, the hand-written `UpdateMembersRequest` interface in `services/rbac.ts`, and the `as number` cast in `ACLEdit.vue`'s zero-role check.
- `api-schema.d.ts` updated with the isolated `Role`-related hunks from the new backend schema.

## Test plan
- [x] `npm run typecheck` -- 0/0 clean
- [x] `npm run lint:check` -- 172/172 clean (unchanged baseline)
- [x] Exhaustive e2e coverage for both role-setting UI paths (ACL grants and a user's global role, across every value the UI offers) added in yeti-platform/yeti-docker
