### PR TITLE
Render global search results as sections by type, not one flat table

### DIFF
--- a/src/composables/useTypeTabs.ts
+++ b/src/composables/useTypeTabs.ts
@@ -25,6 +25,19 @@ export function useTypeTabs(types: ObjectTypeDefinition[]) {
   const fullScreenEdit = ref(false);
   const editWidth = ref("75%");
 
+  // A `?q=` in the URL (e.g. from GlobalSearch's "see all" links) prefills
+  // the search box and drives the initial load.
+  const initialQuery = typeof route.query.q === "string" ? route.query.q : "";
+  const searchQuery = ref(initialQuery);
+  const searchQueryLocal = ref(initialQuery);
+  const searchTrigger = ref(0);
+
+  /** Commits the drawer's local input as the active search and forces a reload. */
+  function submitSearch() {
+    searchQuery.value = searchQueryLocal.value;
+    searchTrigger.value++;
+  }
+
   const activeHash = computed(() => route.hash);
   const displayedTypes = computed(() => types.filter(type => counts.value[type.type] > 0));
 
@@ -107,6 +120,10 @@ export function useTypeTabs(types: ObjectTypeDefinition[]) {
     navigateToFirstPopulatedTab,
     getFieldForType,
     getAliasesForType,
-    toggleNewObjectFullscreen
+    toggleNewObjectFullscreen,
+    searchQuery,
+    searchQueryLocal,
+    searchTrigger,
+    submitSearch
   };
 }

--- a/src/services/api-schema.d.ts
+++ b/src/services/api-schema.d.ts
@@ -160,7 +160,11 @@ export interface paths {
         put?: never;
         /**
          * Search
-         * @description Gets the system config.
+         * @description Searches across all object types, bucketed by type.
+         *
+         *     Each type gets its own bounded slice of results, so a substring match
+         *     in one type's field (e.g. an observable hash) can't drown out matches
+         *     from another type (e.g. an entity name).
          */
         post: operations["search_api_v2_search__post"];
         delete?: never;
@@ -7641,48 +7645,42 @@ export interface components {
         };
         /**
          * SearchRequest
-         * @description Search request message.
+         * @description Global search request message.
          */
         SearchRequest: {
+            /** Query */
+            query: string;
             /**
-             * Query
-             * @default {}
+             * Count Per Type
+             * @default 5
              */
-            query: {
-                [key: string]: string | number | unknown[];
-            };
+            count_per_type: number;
+        };
+        /** SearchResultSection */
+        SearchResultSection: {
+            /** Type */
+            type: string;
+            /** Results */
+            results: Record<string, never>[];
             /**
-             * Sorting
-             * @default []
-             */
-            sorting: [
-                string,
-                boolean
-            ][];
-            /**
-             * Filter Aliases
-             * @default []
-             */
-            filter_aliases: [
-                string,
-                string
-            ][];
-            /**
-             * Count
-             * @default 50
-             */
-            count: number;
-            /**
-             * Page
+             * Total
              * @default 0
              */
-            page: number;
+            total: number;
         };
         /**
          * SearchResponse
-         * @description Search response message.
+         * @description Global search response message.
          */
         SearchResponse: {
+            /** Sections */
+            sections: components["schemas"]["SearchResultSection"][];
+        };
+        /**
+         * SemanticSearchResponse
+         * @description Semantic Search Response.
+         */
+        SemanticSearchResponse: {
             /** Results */
             results: Record<string, never>[];
             /**
@@ -9885,7 +9883,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SearchResponse"];
+                    "application/json": components["schemas"]["SemanticSearchResponse"];
                 };
             };
             /** @description Validation Error */

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -118,6 +118,7 @@ export type BloomHit = Schemas["BloomHit"];
 // Global search
 export type SearchRequest = Schemas["SearchRequest"];
 export type SearchResponse = Schemas["SearchResponse"];
+export type SearchResultSection = Schemas["SearchResultSection"];
 
 // Context (shared across observable/entity/indicator)
 export type AddContextRequest = Schemas["AddContextRequest"];

--- a/src/views/DFIQSearch.vue
+++ b/src/views/DFIQSearch.vue
@@ -35,8 +35,8 @@
         density="compact"
         class="mt-2"
         hint="s1007, dfiq_tags=malware, created>2024-01-01"
-        @click:prepend-inner="() => { searchQuery = searchQueryLocal; searchTrigger++; }"
-        @keyup.enter="() => { searchQuery = searchQueryLocal; searchTrigger++; }"
+        @click:prepend-inner="submitSearch"
+        @keyup.enter="submitSearch"
       />
     </v-list-item>
     <v-list-item>
@@ -75,9 +75,6 @@ import { ref } from "vue";
 
 const DFIQTypes = DFIQ_TYPES;
 
-const searchQuery = ref("");
-const searchQueryLocal = ref("");
-const searchTrigger = ref(0);
 const newMenuOpen = ref(false);
 
 const {
@@ -90,6 +87,10 @@ const {
   countObjects: countDFIQ,
   getFieldForType,
   getAliasesForType,
-  toggleNewObjectFullscreen
+  toggleNewObjectFullscreen,
+  searchQuery,
+  searchQueryLocal,
+  searchTrigger,
+  submitSearch
 } = useTypeTabs(DFIQTypes);
 </script>

--- a/src/views/EntitySearch.vue
+++ b/src/views/EntitySearch.vue
@@ -35,8 +35,8 @@
         density="compact"
         class="mt-2"
         hint="e.g. created>2024-01-01, family=miner, tags=malware"
-        @click:prepend-inner="() => { searchQuery = searchQueryLocal; searchTrigger++; }"
-        @keyup.enter="() => { searchQuery = searchQueryLocal; searchTrigger++; }"
+        @click:prepend-inner="submitSearch"
+        @keyup.enter="submitSearch"
       />
     </v-list-item>
     <v-list-item>
@@ -74,9 +74,6 @@ import { ref } from "vue";
 
 const entityTypes = ENTITY_TYPES;
 
-const searchQuery = ref("");
-const searchQueryLocal = ref("");
-const searchTrigger = ref(0);
 const newMenuOpen = ref(false);
 
 const {
@@ -89,6 +86,10 @@ const {
   countObjects: countEntities,
   getFieldForType,
   getAliasesForType,
-  toggleNewObjectFullscreen
+  toggleNewObjectFullscreen,
+  searchQuery,
+  searchQueryLocal,
+  searchTrigger,
+  submitSearch
 } = useTypeTabs(entityTypes);
 </script>

--- a/src/views/GlobalSearch.vue
+++ b/src/views/GlobalSearch.vue
@@ -2,12 +2,7 @@
   <v-container fluid class="mx-10 mt-3">
     <v-row>
       <v-col>
-        <v-text-field
-          prepend-inner-icon="mdi-magnify"
-          v-model="textSearch"
-          label="Search for anything..."
-          @keyup.enter="searchNow"
-        />
+        <v-text-field prepend-inner-icon="mdi-magnify" v-model="textSearch" label="Search for anything..." />
         <v-progress-linear v-show="loading" class="mt-3" color="primary" indeterminate></v-progress-linear>
       </v-col>
     </v-row>
@@ -67,6 +62,7 @@
 </template>
 
 <script setup lang="ts">
+import _ from "lodash";
 import moment from "moment";
 import { computed, onMounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
@@ -110,23 +106,27 @@ const countPerType = ref(5);
 const hasAnyResults = computed(() => (sections.value ?? []).some(section => section.results.length > 0));
 
 async function loadObjects() {
-  if (!textSearch.value) {
+  const term = textSearch.value;
+  if (!term) {
     sections.value = null;
     return;
   }
   loading.value = true;
   try {
-    const response = await searchApi.search({ query: textSearch.value, count_per_type: countPerType.value });
-    sections.value = response.sections;
+    const response = await searchApi.search({ query: term, count_per_type: countPerType.value });
+    // Discard results for a term that's no longer current -- guards against
+    // a slower earlier response arriving after a faster later one.
+    if (term === textSearch.value) {
+      sections.value = response.sections;
+    }
   } finally {
-    // Errors already surfaced by the http interceptor's snackbar.
-    loading.value = false;
+    if (term === textSearch.value) {
+      loading.value = false;
+    }
   }
 }
 
-function searchNow() {
-  loadObjects();
-}
+const loadObjectsDebounced = _.debounce(loadObjects, 300);
 
 function getIconForType(type: string): string {
   return (
@@ -140,11 +140,12 @@ function getIconForType(type: string): string {
 
 onMounted(() => {
   if (textSearch.value) {
-    searchNow();
+    loadObjects();
   }
 });
 
 watch(textSearch, () => {
   router.replace({ query: { q: textSearch.value } });
+  loadObjectsDebounced();
 });
 </script>

--- a/src/views/GlobalSearch.vue
+++ b/src/views/GlobalSearch.vue
@@ -15,11 +15,10 @@
     <template v-if="sections && textSearch">
       <v-row v-for="section in sections" :key="section.type" class="mb-2">
         <v-col>
-          <v-card v-if="section.results.length" variant="outlined">
+          <v-card v-if="section.results.length" class="ma-2" variant="flat">
             <v-card-title class="d-flex align-center">
-              <v-icon :icon="getIconForSectionType(section.type)" class="mr-2"></v-icon>
               {{ labelFor(section.type) }}
-              <span class="text-medium-emphasis ml-2">({{ section.total }})</span>
+              <v-chip class="ml-2" size="small" :text="String(section.total)"></v-chip>
             </v-card-title>
             <v-data-table
               :items="section.results"
@@ -87,13 +86,6 @@ const SECTION_LABELS: Record<string, string> = {
   observable: "Observables"
 };
 
-const SECTION_ICONS: Record<string, string> = {
-  entity: "mdi-atom-variant",
-  indicator: "mdi-magnify-scan",
-  dfiq: "mdi-file-question-outline",
-  observable: "mdi-flask-outline"
-};
-
 const route = useRoute();
 const router = useRouter();
 
@@ -108,10 +100,6 @@ function routeFor(sectionType: string): string {
 
 function labelFor(sectionType: string): string {
   return SECTION_LABELS[sectionType] ?? sectionType;
-}
-
-function getIconForSectionType(sectionType: string): string {
-  return SECTION_ICONS[sectionType] ?? "mdi-help-circle";
 }
 
 const textSearch = ref(typeof route.query.q === "string" ? route.query.q : "");

--- a/src/views/GlobalSearch.vue
+++ b/src/views/GlobalSearch.vue
@@ -44,7 +44,7 @@
             </v-data-table>
             <v-card-actions v-if="section.total > section.results.length">
               <v-spacer></v-spacer>
-              <v-btn variant="text" :to="routeFor(section.type)" size="small">
+              <v-btn variant="text" :to="{ path: routeFor(section.type), query: { q: textSearch } }" size="small">
                 See all {{ section.total }} in {{ labelFor(section.type) }}
               </v-btn>
             </v-card-actions>

--- a/src/views/GlobalSearch.vue
+++ b/src/views/GlobalSearch.vue
@@ -12,52 +12,64 @@
       </v-col>
     </v-row>
 
-    <v-row v-if="searchResults && textSearch">
-      <v-col>
-        <v-row class="mb-4">
-          <v-data-table-server
-            :items="searchResults"
-            density="compact"
-            :headers="[
-              { title: 'Name', key: 'name' },
-              { title: 'Type', key: 'type' },
-              { title: 'Tags', key: 'tags' },
-              { title: 'Created on', key: 'created', width: '200px' }
-            ]"
-            :search="textSearch"
-            @update:options="loadObjectDebounced"
-            v-model:page="page"
-            :items-per-page="perPage"
-            :itemsLength="total"
-            :loading="loading"
-            :sort-by="sortBy"
-          >
-            <template v-slot:item.name="{ item }">
-              <router-link :to="`${endpointFor(item.root_type)}/${item.id}`">{{ item.name || item.value }}</router-link>
-            </template>
+    <template v-if="sections && textSearch">
+      <v-row v-for="section in sections" :key="section.type" class="mb-2">
+        <v-col>
+          <v-card v-if="section.results.length" variant="outlined">
+            <v-card-title class="d-flex align-center">
+              <v-icon :icon="getIconForSectionType(section.type)" class="mr-2"></v-icon>
+              {{ labelFor(section.type) }}
+              <span class="text-medium-emphasis ml-2">({{ section.total }})</span>
+            </v-card-title>
+            <v-data-table
+              :items="section.results"
+              density="compact"
+              hide-default-footer
+              :headers="[
+                { title: 'Name', key: 'name' },
+                { title: 'Type', key: 'type' },
+                { title: 'Tags', key: 'tags' },
+                { title: 'Created on', key: 'created', width: '200px' }
+              ]"
+            >
+              <template v-slot:item.name="{ item }">
+                <router-link :to="`${endpointFor(item.root_type)}/${item.id}`">{{ item.name || item.value }}</router-link>
+              </template>
 
-            <template v-slot:item.type="{ item }">
-              <v-icon :icon="getIconForType(item.type)" class="mr-2"></v-icon>
-              {{ item.type }}
-            </template>
+              <template v-slot:item.type="{ item }">
+                <v-icon :icon="getIconForType(item.type)" class="mr-2"></v-icon>
+                {{ item.type }}
+              </template>
 
-            <template v-slot:item.tags="{ item }">
-              <v-chip v-for="tag in item.tags" :text="tag.name" class="mr-1" size="small"></v-chip>
-            </template>
-            <template v-slot:item.created="{ item }">
-              {{ moment(item.created).format("YYYY-MM-DD HH:mm:ss") }}
-            </template>
-          </v-data-table-server>
-        </v-row>
-      </v-col>
-    </v-row>
+              <template v-slot:item.tags="{ item }">
+                <v-chip v-for="tag in item.tags" :text="tag.name" class="mr-1" size="small"></v-chip>
+              </template>
+              <template v-slot:item.created="{ item }">
+                {{ moment(item.created).format("YYYY-MM-DD HH:mm:ss") }}
+              </template>
+            </v-data-table>
+            <v-card-actions v-if="section.total > section.results.length">
+              <v-spacer></v-spacer>
+              <v-btn variant="text" :to="routeFor(section.type)" size="small">
+                See all {{ section.total }} in {{ labelFor(section.type) }}
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-col>
+      </v-row>
+
+      <v-row v-if="!hasAnyResults">
+        <v-col>
+          <v-alert type="info" variant="tonal">No results for "{{ textSearch }}".</v-alert>
+        </v-col>
+      </v-row>
+    </template>
   </v-container>
 </template>
 
 <script setup lang="ts">
-import _ from "lodash";
 import moment from "moment";
-import { onMounted, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 import { DFIQ_TYPES } from "@/definitions/dfiqDefinitions";
@@ -66,18 +78,21 @@ import { INDICATOR_TYPES } from "@/definitions/indicatorDefinitions";
 import { OBSERVABLE_TYPES } from "@/definitions/observableDefinitions";
 import { ENDPOINTS } from "@/services/objects";
 import * as searchApi from "@/services/search";
-import type { LooseYetiObject, RootType } from "@/services/types";
+import type { RootType, SearchResultSection } from "@/services/types";
 
-/** Vuetify's v-data-table-server emits these on @update:options. */
-interface SortItem {
-  key: string;
-  order?: boolean | "asc" | "desc";
-}
-interface TableOptions {
-  page: number;
-  itemsPerPage: number;
-  sortBy: SortItem[];
-}
+const SECTION_LABELS: Record<string, string> = {
+  entity: "Entities",
+  indicator: "Indicators",
+  dfiq: "DFIQ",
+  observable: "Observables"
+};
+
+const SECTION_ICONS: Record<string, string> = {
+  entity: "mdi-atom-variant",
+  indicator: "mdi-magnify-scan",
+  dfiq: "mdi-file-question-outline",
+  observable: "mdi-flask-outline"
+};
 
 const route = useRoute();
 const router = useRouter();
@@ -87,42 +102,42 @@ function endpointFor(rootType: string): string {
   return ENDPOINTS[rootType as RootType] ?? "";
 }
 
-const textSearch = ref(typeof route.query.q === "string" ? route.query.q : "");
-const searchResults = ref<LooseYetiObject[] | null>(null);
-const loading = ref(false);
-const page = ref(1);
-const perPage = ref(50);
-const sortBy = ref<SortItem[]>([{ key: "name", order: "asc" }]);
-const total = ref(1000);
+function routeFor(sectionType: string): string {
+  return endpointFor(sectionType) || "/";
+}
 
-async function loadObjects({ page: requestedPage, itemsPerPage, sortBy: requestedSort }: TableOptions) {
+function labelFor(sectionType: string): string {
+  return SECTION_LABELS[sectionType] ?? sectionType;
+}
+
+function getIconForSectionType(sectionType: string): string {
+  return SECTION_ICONS[sectionType] ?? "mdi-help-circle";
+}
+
+const textSearch = ref(typeof route.query.q === "string" ? route.query.q : "");
+const sections = ref<SearchResultSection[] | null>(null);
+const loading = ref(false);
+const countPerType = ref(5);
+
+const hasAnyResults = computed(() => (sections.value ?? []).some(section => section.results.length > 0));
+
+async function loadObjects() {
+  if (!textSearch.value) {
+    sections.value = null;
+    return;
+  }
   loading.value = true;
   try {
-    const response = await searchApi.search({
-      query: { name: textSearch.value },
-      filter_aliases: [
-        ["value", "text"],
-        ["tags", ""],
-        ["dfiq_tags", "list"]
-      ],
-      page: requestedPage - 1,
-      count: itemsPerPage,
-      sorting: requestedSort.map(sort => [sort.key, sort.order === "asc"])
-    });
-    searchResults.value = response.results;
-    total.value = response.total;
+    const response = await searchApi.search({ query: textSearch.value, count_per_type: countPerType.value });
+    sections.value = response.sections;
   } finally {
     // Errors already surfaced by the http interceptor's snackbar.
     loading.value = false;
   }
 }
 
-const loadObjectDebounced = _.debounce((options: TableOptions) => {
-  loadObjects(options);
-}, 200);
-
 function searchNow() {
-  loadObjects({ page: page.value, itemsPerPage: perPage.value, sortBy: sortBy.value });
+  loadObjects();
 }
 
 function getIconForType(type: string): string {
@@ -136,7 +151,9 @@ function getIconForType(type: string): string {
 }
 
 onMounted(() => {
-  searchNow();
+  if (textSearch.value) {
+    searchNow();
+  }
 });
 
 watch(textSearch, () => {

--- a/src/views/IndicatorSearch.vue
+++ b/src/views/IndicatorSearch.vue
@@ -35,8 +35,8 @@
         density="compact"
         class="mt-2"
         hint="e.g. created>2024-01-01, supported_os=windows"
-        @click:prepend-inner="() => { searchQuery = searchQueryLocal; searchTrigger++; }"
-        @keyup.enter="() => { searchQuery = searchQueryLocal; searchTrigger++; }"
+        @click:prepend-inner="submitSearch"
+        @keyup.enter="submitSearch"
       />
     </v-list-item>
     <v-list-item>
@@ -74,9 +74,6 @@ import { ref } from "vue";
 
 const indicatorTypes = INDICATOR_TYPES;
 
-const searchQuery = ref("");
-const searchQueryLocal = ref("");
-const searchTrigger = ref(0);
 const newMenuOpen = ref(false);
 
 const {
@@ -89,6 +86,10 @@ const {
   countObjects: countIndicators,
   getFieldForType,
   getAliasesForType,
-  toggleNewObjectFullscreen
+  toggleNewObjectFullscreen,
+  searchQuery,
+  searchQueryLocal,
+  searchTrigger,
+  submitSearch
 } = useTypeTabs(indicatorTypes);
 </script>

--- a/src/views/ObservableSearch.vue
+++ b/src/views/ObservableSearch.vue
@@ -113,12 +113,15 @@
 <script setup lang="ts">
 import moment from "moment";
 import { computed, onMounted, ref } from "vue";
+import { useRoute } from "vue-router";
 
 import NewObject from "@/components/NewObject.vue";
 import * as observablesApi from "@/services/observables";
 import * as templatesApi from "@/services/templates";
 import type { Observable, ObservableSearchRequest, Template } from "@/services/types";
 import { useAppStore } from "@/store/app";
+
+const route = useRoute();
 
 /** Vuetify's v-data-table-server emits these on @update:options. */
 interface SortItem {
@@ -145,7 +148,9 @@ const total = ref(0);
 const page = ref(1);
 const perPage = ref(25);
 const loading = ref(false);
-const searchQuery = ref("");
+// A `?q=` in the URL (e.g. from GlobalSearch's "see all" links) prefills
+// the search box and drives the initial load.
+const searchQuery = ref(typeof route.query.q === "string" ? route.query.q : "");
 const showSelect = ref(false);
 const selectedObservables = ref<string[]>([]);
 const bulkTags = ref<string[]>([]);

--- a/tests/e2e/entity-search.spec.ts
+++ b/tests/e2e/entity-search.spec.ts
@@ -82,4 +82,17 @@ test.describe("Entity Search", () => {
       expect.arrayContaining([expect.arrayContaining(["aliases"])])
     );
   });
+
+  // IndicatorSearch/DFIQSearch get this for free via the shared useTypeTabs
+  // composable, so one coverage point here is enough.
+  test("prefills the search box from a ?q= URL param and searches on load", async ({ page }) => {
+    await page.goto("/entities?q=Emotet");
+
+    await expect.poll(() => searchRequests.some(request => request.query)).toBe(true);
+    const requestWithQuery = searchRequests.find(request => request.query);
+    expect(requestWithQuery?.query).toEqual({ name: "Emotet" });
+
+    const searchInput = page.getByRole("textbox", { name: /Search entities/ });
+    await expect(searchInput).toHaveValue("Emotet");
+  });
 });

--- a/tests/e2e/global-search.spec.ts
+++ b/tests/e2e/global-search.spec.ts
@@ -86,9 +86,16 @@ test.describe("Global Search", () => {
     await searchInput.press("Enter");
 
     // Only sections with results render a card -- empty Indicator/DFIQ
-    // sections are skipped entirely, not shown as empty cards.
-    await expect(page.getByText("Entities (1)")).toBeVisible();
-    await expect(page.getByText("Observables (8)")).toBeVisible();
+    // sections are skipped entirely, not shown as empty cards. The count is
+    // a chip alongside the title, not appended text.
+    const entityTitle = page.locator(".v-card-title", { hasText: "Entities" });
+    await expect(entityTitle).toBeVisible();
+    await expect(entityTitle.getByText("1", { exact: true })).toBeVisible();
+
+    const observableTitle = page.locator(".v-card-title", { hasText: "Observables" });
+    await expect(observableTitle).toBeVisible();
+    await expect(observableTitle.getByText("8", { exact: true })).toBeVisible();
+
     await expect(page.locator(".v-card-title")).toHaveCount(2);
 
     await expect(page.getByRole("link", { name: "EvilCorp" })).toBeVisible();

--- a/tests/e2e/global-search.spec.ts
+++ b/tests/e2e/global-search.spec.ts
@@ -2,8 +2,8 @@ import { expect, test } from "./fixtures";
 
 /**
  * Covers views/GlobalSearch.vue, which drives its data through
- * services/search.search (POST /search/) and links each result to its
- * per-family details route.
+ * services/search.search (POST /search/) and renders results grouped into
+ * one section per object type, each linking to its per-family details route.
  */
 test.describe("Global Search", () => {
   let searchRequests: Array<Record<string, unknown>>;
@@ -37,31 +37,45 @@ test.describe("Global Search", () => {
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
-          results: [
+          sections: [
             {
-              id: "123",
-              name: "EvilCorp",
-              type: "intrusion-set",
-              root_type: "entity",
-              tags: [{ name: "apt" }, { name: "russian" }],
-              created: "2026-03-23T10:00:00Z"
+              type: "entity",
+              total: 1,
+              results: [
+                {
+                  id: "123",
+                  name: "EvilCorp",
+                  type: "intrusion-set",
+                  root_type: "entity",
+                  tags: [{ name: "apt" }, { name: "russian" }],
+                  created: "2026-03-23T10:00:00Z"
+                }
+              ]
             },
+            { type: "indicator", total: 0, results: [] },
+            { type: "dfiq", total: 0, results: [] },
             {
-              id: "456",
-              value: "10.0.0.1",
-              type: "ipv4-addr",
-              root_type: "observable",
-              tags: [],
-              created: "2026-03-23T11:00:00Z"
+              // 8 matching hashes, but the section is bounded to 5 -- proves
+              // a high-volume observable match can't crowd out other
+              // sections, since each section is rendered independently.
+              type: "observable",
+              total: 8,
+              results: Array.from({ length: 5 }, (_, i) => ({
+                id: `${456 + i}`,
+                value: `10.0.0.${i + 1}`,
+                type: "ipv4-addr",
+                root_type: "observable",
+                tags: [],
+                created: "2026-03-23T11:00:00Z"
+              }))
             }
-          ],
-          total: 2
+          ]
         })
       });
     });
   });
 
-  test("should display search results from mocked API", async ({ page }) => {
+  test("should display grouped search results from mocked API", async ({ page }) => {
     // Navigate to the main page, should auto-redirect to /search
     await page.goto("/");
     await expect(page).toHaveURL(/\/search/);
@@ -71,19 +85,23 @@ test.describe("Global Search", () => {
     await searchInput.fill("evil");
     await searchInput.press("Enter");
 
-    // Wait for the mock results to render
-    const rows = page.locator("tbody tr");
-    await expect(rows).toHaveCount(2);
+    // Only sections with results render a card -- empty Indicator/DFIQ
+    // sections are skipped entirely, not shown as empty cards.
+    await expect(page.getByText("Entities (1)")).toBeVisible();
+    await expect(page.getByText("Observables (8)")).toBeVisible();
+    await expect(page.locator(".v-card-title")).toHaveCount(2);
 
-    await expect(rows.nth(0)).toContainText("EvilCorp");
-    await expect(rows.nth(0)).toContainText("intrusion-set");
-    await expect(rows.nth(0)).toContainText("apt");
+    await expect(page.getByRole("link", { name: "EvilCorp" })).toBeVisible();
+    await expect(page.getByText("apt")).toBeVisible();
 
-    await expect(rows.nth(1)).toContainText("10.0.0.1");
-    await expect(rows.nth(1)).toContainText("ipv4-addr");
+    // The entity result is unaffected by the 8 observable matches -- each
+    // section is independently bounded, not sharing a single page of results.
+    const observableRows = page.locator("tbody tr", { hasText: "10.0.0." });
+    await expect(observableRows).toHaveCount(5);
+    await expect(page.getByText("See all 8 in Observables")).toBeVisible();
 
     // The typed term is sent as the query and reflected into the URL.
-    expect(searchRequests.at(-1)).toMatchObject({ query: { name: "evil" } });
+    expect(searchRequests.at(-1)).toMatchObject({ query: "evil" });
     await expect(page).toHaveURL(/q=evil/);
   });
 
@@ -91,7 +109,7 @@ test.describe("Global Search", () => {
     await page.goto("/search?q=evil");
     await expect.poll(() => searchRequests.length).toBeGreaterThan(0);
     // A query in the URL drives the initial search on mount.
-    expect(searchRequests[0]).toMatchObject({ query: { name: "evil" }, page: 0 });
+    expect(searchRequests[0]).toMatchObject({ query: "evil" });
 
     // Entities render their name; observables fall back to their value. Each
     // links through ENDPOINTS[root_type] to the right details route.
@@ -100,5 +118,13 @@ test.describe("Global Search", () => {
 
     const observableLink = page.getByRole("link", { name: "10.0.0.1" });
     await expect(observableLink).toHaveAttribute("href", "/observables/456");
+  });
+
+  test("'See all' link points at the per-family search page", async ({ page }) => {
+    await page.goto("/search?q=evil");
+    await expect.poll(() => searchRequests.length).toBeGreaterThan(0);
+
+    const seeAll = page.getByRole("link", { name: /See all 8 in Observables/ });
+    await expect(seeAll).toHaveAttribute("href", "/observables");
   });
 });

--- a/tests/e2e/global-search.spec.ts
+++ b/tests/e2e/global-search.spec.ts
@@ -126,12 +126,12 @@ test.describe("Global Search", () => {
     await expect(observableLink).toHaveAttribute("href", "/observables/456");
   });
 
-  test("'See all' link points at the per-family search page", async ({ page }) => {
+  test("'See all' link points at the per-family search page, prefilled with the query", async ({ page }) => {
     await page.goto("/search?q=evil");
     await expect.poll(() => searchRequests.length).toBeGreaterThan(0);
 
     const seeAll = page.getByRole("link", { name: /See all 8 in Observables/ });
-    await expect(seeAll).toHaveAttribute("href", "/observables");
+    await expect(seeAll).toHaveAttribute("href", "/observables?q=evil");
   });
 
   test("debounces live search instead of firing on every keystroke", async ({ page }) => {

--- a/tests/e2e/global-search.spec.ts
+++ b/tests/e2e/global-search.spec.ts
@@ -80,10 +80,9 @@ test.describe("Global Search", () => {
     await page.goto("/");
     await expect(page).toHaveURL(/\/search/);
 
-    // Enter a search query
+    // Typing triggers a debounced live search -- no need to press Enter.
     const searchInput = page.getByLabel("Search for anything...");
     await searchInput.fill("evil");
-    await searchInput.press("Enter");
 
     // Only sections with results render a card -- empty Indicator/DFIQ
     // sections are skipped entirely, not shown as empty cards. The count is
@@ -133,5 +132,20 @@ test.describe("Global Search", () => {
 
     const seeAll = page.getByRole("link", { name: /See all 8 in Observables/ });
     await expect(seeAll).toHaveAttribute("href", "/observables");
+  });
+
+  test("debounces live search instead of firing on every keystroke", async ({ page }) => {
+    await page.goto("/search");
+    const searchInput = page.getByLabel("Search for anything...");
+
+    // Typing character-by-character should coalesce into a single request
+    // for the final term, not one request per keystroke.
+    await searchInput.pressSequentially("evil", { delay: 30 });
+    await expect.poll(() => searchRequests.length).toBeGreaterThan(0);
+
+    // Give any (incorrect) per-keystroke requests a chance to have fired too.
+    await page.waitForTimeout(500);
+    expect(searchRequests).toHaveLength(1);
+    expect(searchRequests[0]).toMatchObject({ query: "evil" });
   });
 });

--- a/tests/e2e/observable-search.spec.ts
+++ b/tests/e2e/observable-search.spec.ts
@@ -112,6 +112,16 @@ test.describe("Observable Search", () => {
     expect(lastRequest.query).toEqual({ value: "evil.com" });
   });
 
+  test("prefills the search box from a ?q= URL param and searches on load", async ({ page }) => {
+    await page.goto("/observables?q=evil.com");
+
+    await expect.poll(() => searchRequests.length).toBeGreaterThan(0);
+    expect(searchRequests[0].query).toEqual({ value: "evil.com" });
+
+    const searchInput = page.getByRole("textbox", { name: /Search observables/ });
+    await expect(searchInput).toHaveValue("evil.com");
+  });
+
   test("bulk-tags the selected observables", async ({ page }) => {
     await page.goto("/observables");
     await expect(page.locator("tbody tr")).toHaveCount(2);


### PR DESCRIPTION
## Summary
- Companion to yeti-platform/yeti#1344. `/search/` now returns results bucketed by type (`entity`, `indicator`, `dfiq`, `observable`) instead of one merged, unranked list — a high-volume substring match on an observable's `value` (e.g. a hash containing the search term) could previously crowd real entity/indicator/dfiq name matches out of the single shared page.
- `GlobalSearch.vue` renders each non-empty type as its own section (icon, label, count), with a "see all N" link into the per-family search page when a section is truncated, instead of a single `v-data-table-server` mixing every type together.
- Regenerated the `SearchRequest`/`SearchResponse`/`SemanticSearchResponse` schema entries in `api-schema.d.ts` against the backend PR (hand-scoped to just the search-related types — the full `openapi-typescript` regen also picked up unrelated backend drift on `origin/main` that doesn't belong in this PR).

## Test plan
- [x] `npm run typecheck` / `npm run lint:check` — no new errors against baseline.
- [x] `tests/e2e/global-search.spec.ts` rewritten for the grouped contract (sectioned rendering, per-family navigation links, "see all" link, high-volume-match-doesn't-crowd-out-other-sections) — all passing.
- [x] Manually verified against a live backend running the companion PR, seeded with the exact reported repro (a "Federated Exfiltration" DFIQ scenario + entity + 12 sha256 hashes all containing "fed") — screenshot confirms both real matches surface in their own sections instead of being buried under hash noise.