### PR TITLE
Fix DFIQ Edit button hidden for non-admins when RBAC is disabled

### DIFF
--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 
 import * as authApi from "@/services/auth";
+import { useAppStore } from "@/store/app";
 import type { LooseYetiObject, User } from "@/services/types";
 
 /**
@@ -67,7 +68,12 @@ export const useUserStore = defineStore("user", {
       if (this.user.admin) {
         return true;
       }
-      // Objects outside RBAC (and DFIQ) carry no acls at all.
+      // Mirrors the backend's permission_on_target()/global_permission()
+      // decorators: with RBAC disabled, every authenticated user has full
+      // read/write/delete on every object, regardless of ACLs.
+      if (!useAppStore().RBACEnabled) {
+        return true;
+      }
       const granted = object?.acls?.[this.user.username]?.role ?? 0;
       return (granted & role) === role;
     }

--- a/tests/e2e/dfiq-edit-rbac-disabled.spec.ts
+++ b/tests/e2e/dfiq-edit-rbac-disabled.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * Regression test for a bug where non-admin users never saw the Edit button
+ * on DFIQ objects (and, by the same shared `hasRole` check, on any object
+ * type) whenever the deployment had RBAC disabled. The backend's
+ * permission_on_target()/global_permission() decorators bypass ACL checks
+ * entirely when RBAC is off (see core/schemas/rbac.py) -- any authenticated
+ * user can write anything -- but the frontend's hasRole() only special-cased
+ * `user.admin`, so a non-admin/non-owner still failed the ACL lookup and the
+ * button stayed hidden even though the write would have succeeded.
+ */
+
+const scenario = {
+  id: "555",
+  dfiq_id: "S1001",
+  name: "Suspicious DNS Query",
+  description: "A scenario.",
+  type: "scenario",
+  root_type: "dfiq",
+  dfiq_tags: [],
+  tags: [],
+  acls: {},
+  created: "2026-03-23T10:00:00Z",
+  modified: "2026-03-23T10:00:00Z"
+};
+
+test.describe("DFIQ Edit button vs. RBAC-enabled flag", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/v2/auth/me", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ username: "nonadmin", admin: false, email: "test@example.com" })
+      });
+    });
+
+    await page.route("**/api/v2/dfiq/555", async route => {
+      if (route.request().method() !== "GET") {
+        await route.fallback();
+        return;
+      }
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(scenario) });
+    });
+
+    await page.route("**/api/v2/graph/search", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ vertices: {}, paths: [], total: 0 })
+      });
+    });
+  });
+
+  test("shows Edit for a non-admin, non-owner user when RBAC is disabled", async ({ page }) => {
+    await page.route("**/api/v2/system/config", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ rbac_enabled: false, agents_enabled: false, system: { templates_dir: "/t" } })
+      });
+    });
+
+    await page.goto("/dfiq/555");
+
+    await expect(page.getByRole("button", { name: "Edit" })).toBeVisible();
+  });
+
+  test("hides Edit for a non-admin, non-owner user when RBAC is enabled", async ({ page }) => {
+    await page.route("**/api/v2/system/config", async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ rbac_enabled: true, agents_enabled: false, system: { templates_dir: "/t" } })
+      });
+    });
+
+    await page.goto("/dfiq/555");
+    // Let the page settle so this isn't just "hasn't rendered yet".
+    await expect(page.getByText("Suspicious DNS Query").first()).toBeVisible();
+
+    await expect(page.getByRole("button", { name: "Edit" })).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
Non-admin users never saw the Edit button on DFIQ objects (Scenario/Facet/Question all share `ObjectDetails.vue`), even though they could actually save edits made via the DFIQ tree's per-node pencils. Same root cause also affects the Share button and the Delete-object button inside the edit dialog, and generalizes to any object type, not just DFIQ.

**Root cause**: `userStore.hasRole()` special-cases admins, then falls back to a per-object ACL lookup (`object.acls[username]`). But the backend's `permission_on_target()`/`global_permission()` decorators (`core/schemas/rbac.py`) bypass ACL checks entirely whenever RBAC is disabled — `if not RBAC_ENABLED or user.admin: <bypass>` — meaning any authenticated user can write anything in that mode. The frontend never mirrored that bypass, so a non-admin/non-owner (the normal case for DFIQ objects, which are typically imported by an admin) saw the button hidden even though their write would have succeeded. This is exactly why DFIQ *tree* editing "worked" for non-admins while the *Scenario* page's Edit button didn't: the tree's pencils have no frontend permission check at all and just let the backend decide, while the top-level Edit/Share buttons went through the broken `hasRole()`.

**Fix**: `hasRole()` now also returns `true` for any authenticated user when `appStore.RBACEnabled` is `false`, mirroring the backend exactly.

## Test plan
- [x] Live-verified against real dev data: minted a non-admin session, confirmed Edit was hidden on a DFIQ Scenario before the fix and visible after (dev's `yeti.conf` has `rbac.enabled = False`, so this reproduces directly).
- [x] New e2e spec `tests/e2e/dfiq-edit-rbac-disabled.spec.ts`: Edit shown for a non-admin/non-owner when RBAC is disabled, hidden when RBAC is enabled (regression guard for the normal case).
- [x] Full e2e suite: 59/59 passing.
- [x] `vue-tsc --noEmit` and `eslint` clean.